### PR TITLE
fix: harden reranking and pipeline retries for 0.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,7 +683,7 @@ jobs:
           file: frontend/Dockerfile
           build-args: |
             PUBLIC_APP_ID=docsmint
-            PUBLIC_DEPLOYMENT_ID=docsmint-oss-0.8.1
+            PUBLIC_DEPLOYMENT_ID=docsmint-oss-0.8.2
           push: true
           tags: |
             ghcr.io/hiai-gg/docsmint-web:${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-08-31
+
+### Added
+
+- Pipeline status exposes machine-readable graph and summary warnings, including
+  stable error codes and retryability.
+- `POST /api/documents/:id/pipeline/retry-warnings` and the SDK
+  `retryDocumentPipelineWarnings()` method retry only failed optional stages on
+  the active embedding generation.
+
+### Fixed
+
+- Preserve candidate identity when empty rerank documents are filtered, so
+  provider indexes and scores always map back to the correct document IDs.
+- Import theme spread and UI components through published `hiai-ui` package
+  exports without SvelteKit source or distribution aliases.
+- Keep optional-stage diagnostics independent, retry transient provider
+  failures with the configured BullMQ backoff, and avoid regenerating an
+  already-ready summary during graph-only recovery.
+
 ## [0.8.1] - 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -46,22 +46,16 @@ TypeScript SDK, CLI, and MCP server.
 - **Own the full stack**: application data, vectors, graph, queue, and files run
   on infrastructure you control.
 
-## What's new in 0.8.1?
+## What's new in 0.8.2?
 
-- **Reliable GraphRAG on pooled connections.** AGE expansion pins
-  `ag_catalog` on the same PostgreSQL connection as `cypher()`, so scoped
-  search keeps graph neighbors regardless of the connection's previous
-  `search_path`.
-- **Better answers after hybrid retrieval.** Cross-encoder rerank promotes the
-  most relevant results after RRF while remaining fail-open when a provider is
-  unavailable. In the labeled live evaluation, MRR reached **1.000** and
-  nDCG@10 reached **0.986**, with Recall@10 unchanged at **1.000**.
-- **Resilient AI providers.** Embeddings, entity extraction, query expansion,
-  and rerank each support a primary model plus two fallbacks, so one provider
-  outage does not remove an entire retrieval channel.
-- **Secure agent access.** Signed workspace assertions can limit REST, SDK,
-  CLI, and MCP clients to one category with independent `read`, `edit`, and
-  `write` permissions.
+- **Correct rerank identity.** Empty candidates can no longer shift provider
+  scores onto the wrong document ID; partial and invalid provider responses
+  still preserve stable RRF fallback order.
+- **Recover optional AI stages safely.** Pipeline status includes typed graph
+  and summary warnings, and the API or SDK can retry only failed enrichment on
+  the current embedding generation without rebuilding ready chunks.
+- **Reliable public frontend imports.** The standalone frontend consumes only
+  published `hiai-ui` exports, with no source or distribution aliases.
 
 Read the complete release history in the [changelog](CHANGELOG.md) or
 [GitHub Releases](https://github.com/HiAi-gg/docsmint/releases). See the

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-docs/backend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/backend/src/__tests__/document-index-route-contract.test.ts
+++ b/backend/src/__tests__/document-index-route-contract.test.ts
@@ -5,19 +5,19 @@ const source = await Bun.file(
 ).text();
 
 describe("document knowledge route contract", () => {
-	test("validates all three route ids before querying UUID columns", () => {
+	test("validates all four route ids before querying UUID columns", () => {
 		expect(
 			source.match(/documentIdParamsSchema\.safeParse\(params\)/g),
-		).toHaveLength(3);
+		).toHaveLength(4);
 	});
 
-	test("rate limits summary and status reads plus index refresh writes", () => {
+	test("rate limits summary and status reads plus warning retry and index refresh writes", () => {
 		const routeBlock = source.slice(
-			source.indexOf('.get("/documents/:id/knowledge-summary"'),
+			source.indexOf('"/documents/:id/pipeline/retry-warnings"'),
 			source.indexOf('.get("/documents/:id",'),
 		);
 		expect(routeBlock.match(/documentRateLimiter\(/g)).toHaveLength(2);
-		expect(routeBlock.match(/writeRateLimiter\(/g)).toHaveLength(1);
+		expect(routeBlock.match(/writeRateLimiter\(/g)).toHaveLength(2);
 		expect(routeBlock).toContain("set.status = 429");
 	});
 });

--- a/backend/src/__tests__/document-index-route-contract.test.ts
+++ b/backend/src/__tests__/document-index-route-contract.test.ts
@@ -20,4 +20,24 @@ describe("document knowledge route contract", () => {
 		expect(routeBlock.match(/writeRateLimiter\(/g)).toHaveLength(2);
 		expect(routeBlock).toContain("set.status = 429");
 	});
+
+	test("fences warning retries to the current revision and uses a stable queue identity", () => {
+		const routeBlock = source.slice(
+			source.indexOf('"/documents/:id/pipeline/retry-warnings"'),
+			source.indexOf('.get("/documents/:id",'),
+		);
+		expect(routeBlock).toContain(
+			"eq(documents.contentHash, documentPipelineRuns.revision)",
+		);
+		expect(routeBlock).toContain(
+			"warningRetryJobId(stage, retry.generationId)",
+		);
+		expect(routeBlock).toContain("deduplicated: true");
+		expect(routeBlock).toContain('["retrying", "processing"].includes(');
+		expect(routeBlock).toContain('existingRetryState === "completed"');
+		expect(routeBlock).toContain('existingRetryState === "failed"');
+		expect(routeBlock).toContain("await existingRetryJob?.remove()");
+		expect(routeBlock).toContain("resolveActiveWarningRetry(");
+		expect(routeBlock).not.toContain("Date.now()");
+	});
 });

--- a/backend/src/__tests__/graph-worker.test.ts
+++ b/backend/src/__tests__/graph-worker.test.ts
@@ -34,6 +34,25 @@ function deps(
 }
 
 describe("graph worker isolation", () => {
+	it("graph-only retry finalizes without regenerating a ready summary", async () => {
+		const effects: string[] = [];
+		const state = deps({
+			getRun: async () => ({
+				...job,
+				embedStatus: "ready" as const,
+				summarizeStatus: "ready" as const,
+			}),
+			enqueueSummarize: async () => {
+				effects.push("summarize");
+			},
+			enqueueFinalize: async () => {
+				effects.push("finalize");
+			},
+		});
+		await createGraphWorker(state)(job);
+		expect(effects).toEqual(["finalize"]);
+	});
+
 	it("records an unavailable graph dependency as an optional warning", async () => {
 		const effects: string[] = [];
 		const state = deps({

--- a/backend/src/__tests__/graph-worker.test.ts
+++ b/backend/src/__tests__/graph-worker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { PipelineProviderError } from "../lib/pipeline-error";
 import {
 	createGraphWorker,
 	type PipelineStageStatus,
@@ -51,6 +52,37 @@ describe("graph worker isolation", () => {
 		});
 		await createGraphWorker(state)(job);
 		expect(effects).toEqual(["finalize"]);
+	});
+
+	it("graph-only retry failure preserves a ready summary and still finalizes", async () => {
+		const effects: string[] = [];
+		const state = deps({
+			getRun: async () => ({
+				...job,
+				embedStatus: "ready" as const,
+				summarizeStatus: "ready" as const,
+			}),
+			extract: async () => {
+				throw new PipelineProviderError("provider_timeout", true);
+			},
+			setGraphStatus: async (_id, status, errorCode) => {
+				effects.push(`${status}:${errorCode ?? ""}`);
+			},
+			enqueueSummarize: async () => {
+				effects.push("summarize");
+			},
+			enqueueFinalize: async () => {
+				effects.push("finalize");
+			},
+		});
+		await expect(createGraphWorker(state)(job)).rejects.toThrow(
+			"provider_timeout",
+		);
+		expect(effects).toEqual([
+			"processing:",
+			"failed:provider_timeout",
+			"finalize",
+		]);
 	});
 
 	it("records an unavailable graph dependency as an optional warning", async () => {

--- a/backend/src/__tests__/knowledge-summary.test.ts
+++ b/backend/src/__tests__/knowledge-summary.test.ts
@@ -42,7 +42,7 @@ describe("knowledge summary generation", () => {
 				{ title: "Roadmap", content: "Milestones", revision: "rev-1" },
 				async () => null,
 			),
-		).rejects.toThrow("summary_provider_failed");
+		).rejects.toThrow("provider_failure");
 	});
 });
 

--- a/backend/src/__tests__/openai-compatible-chat.test.ts
+++ b/backend/src/__tests__/openai-compatible-chat.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { z } from "zod";
 import {
 	requestStructuredChat,
+	requestStructuredChatDetailed,
 	resolveChatProviderKey,
 	uniqueChatProviders,
 } from "../lib/openai-compatible-chat";
@@ -126,5 +127,31 @@ describe("structured chat fallback chain", () => {
 			outputSchema,
 		});
 		expect(result).toBeNull();
+	});
+
+	test("classifies malformed JSON and schema validation separately", async () => {
+		globalThis.fetch = mock(async () =>
+			completion("not-json"),
+		) as unknown as typeof fetch;
+		const malformed = await requestStructuredChatDetailed({
+			primary: chatProvider("primary"),
+			messages: [{ role: "user", content: "q" }],
+			outputSchema,
+		});
+		expect(malformed.ok ? null : malformed.error.code).toBe(
+			"invalid_provider_response",
+		);
+
+		globalThis.fetch = mock(async () =>
+			completion(JSON.stringify({ nope: true })),
+		) as unknown as typeof fetch;
+		const invalid = await requestStructuredChatDetailed({
+			primary: chatProvider("primary"),
+			messages: [{ role: "user", content: "q" }],
+			outputSchema,
+		});
+		expect(invalid.ok ? null : invalid.error.code).toBe(
+			"permanent_validation_failure",
+		);
 	});
 });

--- a/backend/src/__tests__/openapi-external-contract.test.ts
+++ b/backend/src/__tests__/openapi-external-contract.test.ts
@@ -93,7 +93,7 @@ describe("OpenAPI external integration contract", () => {
 		expect(new Set(committedInventory).size).toBe(committedInventory.length);
 	});
 	test("tracks the release version and critical SDK, CLI, and MCP routes", () => {
-		expect(spec.info.version).toBe("0.8.1");
+		expect(spec.info.version).toBe("0.8.2");
 		for (const [method, path] of requiredOperations) {
 			expect(
 				spec.paths[path]?.[method],

--- a/backend/src/__tests__/pipeline-error.test.ts
+++ b/backend/src/__tests__/pipeline-error.test.ts
@@ -21,8 +21,18 @@ describe("pipeline provider diagnostics", () => {
 
 	it("marks permanent validation failures as non-retryable", () => {
 		expect(isRetryablePipelineError("provider_timeout")).toBe(true);
+		expect(isRetryablePipelineError("invalid_provider_response")).toBe(true);
 		expect(isRetryablePipelineError("permanent_validation_failure")).toBe(
 			false,
 		);
+		expect(isRetryablePipelineError("provider_unavailable")).toBe(false);
+		expect(isRetryablePipelineError("stale_revision")).toBe(false);
+		expect(isRetryablePipelineError("arbitrary internal message")).toBe(false);
+	});
+
+	it("does not expose arbitrary exception messages as diagnostic codes", () => {
+		expect(
+			pipelineErrorCode(new Error("secret provider detail"), "failed"),
+		).toBe("failed");
 	});
 });

--- a/backend/src/__tests__/pipeline-error.test.ts
+++ b/backend/src/__tests__/pipeline-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import {
+	isRetryablePipelineError,
+	PipelineProviderError,
+	pipelineErrorCode,
+} from "../lib/pipeline-error";
+
+describe("pipeline provider diagnostics", () => {
+	it("keeps timeout, provider, response, and validation failures distinct", () => {
+		for (const code of [
+			"provider_timeout",
+			"provider_failure",
+			"invalid_provider_response",
+			"permanent_validation_failure",
+		] as const) {
+			expect(
+				pipelineErrorCode(new PipelineProviderError(code, true), "x"),
+			).toBe(code);
+		}
+	});
+
+	it("marks permanent validation failures as non-retryable", () => {
+		expect(isRetryablePipelineError("provider_timeout")).toBe(true);
+		expect(isRetryablePipelineError("permanent_validation_failure")).toBe(
+			false,
+		);
+	});
+});

--- a/backend/src/__tests__/pipeline-warning-retry.test.ts
+++ b/backend/src/__tests__/pipeline-warning-retry.test.ts
@@ -1,7 +1,44 @@
 import { describe, expect, it } from "bun:test";
-import { planWarningStageRetry } from "../queue/pipeline-warning-retry";
+import {
+	planWarningStageRetry,
+	resolveActiveWarningRetry,
+	summaryJobIdForPipeline,
+	warningRetryJobId,
+} from "../queue/pipeline-warning-retry";
 
 describe("warning-stage retry planning", () => {
+	it("distinguishes a warning worker from an ordinary processing stage", () => {
+		expect(resolveActiveWarningRetry(true, false)).toBe("conflict");
+		expect(resolveActiveWarningRetry(true, true)).toBe("deduplicate");
+		expect(resolveActiveWarningRetry(false, false)).toBe("enqueue");
+	});
+
+	it("never re-enqueues a started retry when its retained job turns terminal", () => {
+		// The decision intentionally depends on identity, not a racy BullMQ state
+		// snapshot: a job that finishes between lookup and response remains a no-op.
+		expect(resolveActiveWarningRetry(true, true)).toBe("deduplicate");
+	});
+
+	it("keeps the same warning identity when a graph retry advances to summary", () => {
+		expect(warningRetryJobId("graph", "generation-a")).toBe(
+			"graph-warning-retry-generation-a",
+		);
+		expect(warningRetryJobId("summarize", "generation-a")).toBe(
+			"summarize-warning-retry-generation-a",
+		);
+		expect(
+			summaryJobIdForPipeline({
+				generationId: "generation-a",
+				warningRetry: true,
+			}),
+		).toBe("summarize-warning-retry-generation-a");
+		expect(
+			summaryJobIdForPipeline({
+				generationId: "generation-a",
+				workspaceId: "workspace-a",
+			}),
+		).toBe("summary-generation-a-workspace-a");
+	});
 	it("retries graph only without selecting an already-ready summary", () => {
 		expect(
 			planWarningStageRetry({

--- a/backend/src/__tests__/pipeline-warning-retry.test.ts
+++ b/backend/src/__tests__/pipeline-warning-retry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { planWarningStageRetry } from "../queue/pipeline-warning-retry";
+
+describe("warning-stage retry planning", () => {
+	it("retries graph only without selecting an already-ready summary", () => {
+		expect(
+			planWarningStageRetry({
+				graphStatus: "failed",
+				summarizeStatus: "ready",
+				graphErrorCode: "provider_timeout",
+				summarizeErrorCode: null,
+			}),
+		).toEqual({ graph: true, summarize: false, entryStage: "graph" });
+	});
+
+	it("starts at graph when both optional stages failed", () => {
+		expect(
+			planWarningStageRetry({
+				graphStatus: "failed",
+				summarizeStatus: "failed",
+				graphErrorCode: "provider_failure",
+				summarizeErrorCode: "invalid_provider_response",
+			}),
+		).toEqual({ graph: true, summarize: true, entryStage: "graph" });
+	});
+
+	it("does not retry permanent validation failures or claimed stages", () => {
+		expect(
+			planWarningStageRetry({
+				graphStatus: "failed",
+				summarizeStatus: "ready",
+				graphErrorCode: "permanent_validation_failure",
+				summarizeErrorCode: null,
+			}),
+		).toBeNull();
+		expect(
+			planWarningStageRetry({
+				graphStatus: "retrying",
+				summarizeStatus: "ready",
+				graphErrorCode: null,
+				summarizeErrorCode: null,
+			}),
+		).toBeNull();
+	});
+});

--- a/backend/src/__tests__/rerank-provider.test.ts
+++ b/backend/src/__tests__/rerank-provider.test.ts
@@ -31,6 +31,17 @@ afterEach(() => {
 });
 
 describe("OpenRouter rerank provider", () => {
+	function configurePrimary() {
+		Object.assign(config, {
+			SEARCH_RERANK_BASE_URL: "https://primary.test/v1",
+			SEARCH_RERANK_MODEL: "voyageai/rerank-2.5",
+			SEARCH_RERANK_FALLBACK_BASE_URL: "",
+			SEARCH_RERANK_FALLBACK_MODEL: "",
+			SEARCH_RERANK_FALLBACK_2_BASE_URL: "",
+			SEARCH_RERANK_FALLBACK_2_MODEL: "",
+		});
+	}
+
 	test("maps provider indexes onto candidate ids", async () => {
 		Object.assign(config, {
 			SEARCH_RERANK_BASE_URL: "https://primary.test/v1",
@@ -110,5 +121,131 @@ describe("OpenRouter rerank provider", () => {
 			}),
 		).toBeNull();
 		expect(getMetrics()[METRIC_NAMES.SEARCH_RERANK_FALLBACK_TOTAL]).toBe(1);
+	});
+
+	test.each([
+		{
+			name: "first",
+			candidates: [
+				{ id: "empty", text: "  " },
+				{ id: "doc-a", text: "alpha" },
+				{ id: "doc-b", text: "beta" },
+			],
+		},
+		{
+			name: "middle",
+			candidates: [
+				{ id: "doc-a", text: "alpha" },
+				{ id: "empty", text: "\n\t" },
+				{ id: "doc-b", text: "beta" },
+			],
+		},
+		{
+			name: "multiple positions",
+			candidates: [
+				{ id: "empty-a", text: "" },
+				{ id: "doc-a", text: "alpha" },
+				{ id: "empty-b", text: "  " },
+				{ id: "doc-b", text: "beta" },
+				{ id: "empty-c", text: "\n" },
+			],
+		},
+	])("keeps IDs aligned when empty candidates occur $name", async ({ candidates }) => {
+		configurePrimary();
+		let requestBody: { documents?: string[] } = {};
+		globalThis.fetch = mock(async (_url, init) => {
+			requestBody = JSON.parse(String(init?.body));
+			return new Response(
+				JSON.stringify({
+					results: [
+						{ index: 1, relevance_score: 0.91 },
+						{ index: 0, relevance_score: 0.42 },
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const result = await requestRerank({ query: "q", candidates: [...candidates] });
+
+		expect(requestBody.documents).toEqual(["alpha", "beta"]);
+		expect(result?.hits).toEqual([
+			{ id: "doc-b", score: 0.91, rank: 1 },
+			{ id: "doc-a", score: 0.42, rank: 2 },
+		]);
+	});
+
+	test("does not call a provider when every candidate is empty", async () => {
+		configurePrimary();
+		const provider = mock(async () => new Response("unexpected"));
+		globalThis.fetch = provider as unknown as typeof fetch;
+
+		expect(
+			await requestRerank({
+				query: "q",
+				candidates: [
+					{ id: "empty-a", text: "" },
+					{ id: "empty-b", text: " \n\t" },
+				],
+			}),
+		).toBeNull();
+		expect(provider).not.toHaveBeenCalled();
+	});
+
+	test("keeps a partial response attached to the filtered document ID", async () => {
+		configurePrimary();
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						results: [{ index: 1, relevance_score: 0.75 }],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		const result = await requestRerank({
+			query: "q",
+			candidates: [
+				{ id: "empty", text: "" },
+				{ id: "doc-a", text: "alpha" },
+				{ id: "doc-b", text: "beta" },
+				{ id: "doc-c", text: "gamma" },
+			],
+		});
+		expect(result?.hits).toEqual([{ id: "doc-b", score: 0.75, rank: 1 }]);
+	});
+
+	test("ignores invalid indexes and duplicate provider hits", async () => {
+		configurePrimary();
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						results: [
+							{ index: 7, relevance_score: 1 },
+							{ index: -1, relevance_score: 0.99 },
+							{ index: 0.5, relevance_score: 0.98 },
+							{ index: 1, relevance_score: 0.8 },
+							{ index: 1, relevance_score: 0.7 },
+							{ index: 2, relevance_score: 0.6 },
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		const result = await requestRerank({
+			query: "q",
+			candidates: [
+				{ id: "empty", text: "" },
+				{ id: "doc-a", text: "alpha" },
+				{ id: "doc-b", text: "beta" },
+				{ id: "doc-b", text: "beta duplicate" },
+			],
+		});
+		expect(result?.hits).toEqual([
+			{ id: "doc-b", score: 0.8, rank: 4 },
+		]);
 	});
 });

--- a/backend/src/__tests__/rerank-provider.test.ts
+++ b/backend/src/__tests__/rerank-provider.test.ts
@@ -150,7 +150,9 @@ describe("OpenRouter rerank provider", () => {
 				{ id: "empty-c", text: "\n" },
 			],
 		},
-	])("keeps IDs aligned when empty candidates occur $name", async ({ candidates }) => {
+	])("keeps IDs aligned when empty candidates occur $name", async ({
+		candidates,
+	}) => {
 		configurePrimary();
 		let requestBody: { documents?: string[] } = {};
 		globalThis.fetch = mock(async (_url, init) => {
@@ -166,7 +168,10 @@ describe("OpenRouter rerank provider", () => {
 			);
 		}) as unknown as typeof fetch;
 
-		const result = await requestRerank({ query: "q", candidates: [...candidates] });
+		const result = await requestRerank({
+			query: "q",
+			candidates: [...candidates],
+		});
 
 		expect(requestBody.documents).toEqual(["alpha", "beta"]);
 		expect(result?.hits).toEqual([
@@ -244,8 +249,6 @@ describe("OpenRouter rerank provider", () => {
 				{ id: "doc-b", text: "beta duplicate" },
 			],
 		});
-		expect(result?.hits).toEqual([
-			{ id: "doc-b", score: 0.8, rank: 4 },
-		]);
+		expect(result?.hits).toEqual([{ id: "doc-b", score: 0.8, rank: 4 }]);
 	});
 });

--- a/backend/src/api/routes/documents.ts
+++ b/backend/src/api/routes/documents.ts
@@ -1073,6 +1073,23 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 	.post(
 		"/documents/:id/pipeline/retry-warnings",
 		async ({ params, set, request }) => {
+			const parsedParams = documentIdParamsSchema.safeParse(params);
+			if (!parsedParams.success) {
+				set.status = 400;
+				return { error: "Invalid document id" };
+			}
+			const documentId = parsedParams.data.id;
+			const ip =
+				request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+				request.headers.get("x-real-ip") ??
+				"unknown";
+			const rl = await writeRateLimiter(ip, request);
+			if (!rl.allowed) {
+				set.status = 429;
+				set.headers = rateLimitHeaders(0, rl.retryAfter);
+				return { error: "Too many requests" };
+			}
+			set.headers = rateLimitHeaders(rl.remaining);
 			const access = await resolveContentAccess(request);
 			const ctx = access.ctx;
 			if (ctx.role === "none") {
@@ -1088,7 +1105,7 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 				| undefined;
 			try {
 				const retry = await withTenant(ctx, async (tx) => {
-					await acquireDocumentPipelineLock(tx, params.id);
+					await acquireDocumentPipelineLock(tx, documentId);
 					const [run] = await tx
 						.select({
 							generationId: documentPipelineRuns.generationId,
@@ -1116,8 +1133,12 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 						)
 						.where(
 							and(
-								eq(documentPipelineRuns.documentId, params.id),
-								eq(documentPipelineRuns.ownerId, ctx.userId),
+								eq(documentPipelineRuns.documentId, documentId),
+								tenantOwnerCondition(
+									documents.ownerId,
+									documents.workspaceId,
+									ctx,
+								),
 								eq(documentPipelineRuns.status, "ready_with_warnings"),
 								eq(documentPipelineRuns.embedStatus, "ready"),
 								isNull(documents.deletedAt),
@@ -1197,7 +1218,7 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 				const data: PipelineJob = {
 					schemaVersion: PIPELINE_SCHEMA_VERSION,
 					stage,
-					documentId: params.id,
+					documentId,
 					ownerId: retry.ownerId,
 					...(retry.workspaceId ? { workspaceId: retry.workspaceId } : {}),
 					generationId: retry.generationId,
@@ -1216,7 +1237,7 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 					priority: SOURCE_PRIORITY.api,
 				});
 				return {
-					documentId: params.id,
+					documentId,
 					generationId: retry.generationId,
 					retriedStages: [
 						...(retry.graph ? (["graph"] as const) : []),
@@ -1257,10 +1278,7 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 							),
 					).catch(() => undefined);
 				}
-				logger.error(
-					{ err, documentId: params.id },
-					"Failed to retry warning stages",
-				);
+				logger.error({ err, documentId }, "Failed to retry warning stages");
 				set.status = 500;
 				return { error: "Failed to retry warning stages" };
 			}
@@ -1432,6 +1450,8 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 					embedStatus: documentPipelineRuns.embedStatus,
 					graphStatus: documentPipelineRuns.graphStatus,
 					summarizeStatus: documentPipelineRuns.summarizeStatus,
+					graphErrorCode: documentPipelineRuns.graphErrorCode,
+					summarizeErrorCode: documentPipelineRuns.summarizeErrorCode,
 					finalizeStatus: documentPipelineRuns.finalizeStatus,
 					totalBatches: documentPipelineRuns.totalBatches,
 					completedBatches: documentPipelineRuns.completedBatches,
@@ -1480,6 +1500,30 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 							completed: run.completedBatches,
 							failed: run.failedBatches,
 						},
+						warnings: [
+							...(run.graphStatus === "failed"
+								? [
+										{
+											stage: "graph" as const,
+											code: run.graphErrorCode ?? "graph_failed",
+											retryable: isRetryablePipelineError(
+												run.graphErrorCode ?? "graph_failed",
+											),
+										},
+									]
+								: []),
+							...(run.summarizeStatus === "failed"
+								? [
+										{
+											stage: "summarize" as const,
+											code: run.summarizeErrorCode ?? "summary_failed",
+											retryable: isRetryablePipelineError(
+												run.summarizeErrorCode ?? "summary_failed",
+											),
+										},
+									]
+								: []),
+						],
 						updatedAt: run.updatedAt,
 					}
 				: null,

--- a/backend/src/api/routes/documents.ts
+++ b/backend/src/api/routes/documents.ts
@@ -99,7 +99,11 @@ import {
 } from "../../queue/contracts";
 import { enqueueDocumentPipeline } from "../../queue/enqueue";
 import { DEFAULT_JOB_OPTIONS, SOURCE_PRIORITY } from "../../queue/names";
-import { planWarningStageRetry } from "../../queue/pipeline-warning-retry";
+import {
+	planWarningStageRetry,
+	resolveActiveWarningRetry,
+	warningRetryJobId,
+} from "../../queue/pipeline-warning-retry";
 import { getPipelineQueue } from "../../queue/queues";
 import {
 	documentRateLimiter,
@@ -1108,6 +1112,7 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 					await acquireDocumentPipelineLock(tx, documentId);
 					const [run] = await tx
 						.select({
+							status: documentPipelineRuns.status,
 							generationId: documentPipelineRuns.generationId,
 							revision: documentPipelineRuns.revision,
 							ownerId: documentPipelineRuns.ownerId,
@@ -1129,6 +1134,7 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 									documents.activeEmbeddingGeneration,
 									documentPipelineRuns.generationId,
 								),
+								eq(documents.contentHash, documentPipelineRuns.revision),
 							),
 						)
 						.where(
@@ -1139,7 +1145,6 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 									documents.workspaceId,
 									ctx,
 								),
-								eq(documentPipelineRuns.status, "ready_with_warnings"),
 								eq(documentPipelineRuns.embedStatus, "ready"),
 								isNull(documents.deletedAt),
 								...(access.restricted
@@ -1160,6 +1165,24 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 						.limit(1)
 						.for("update");
 					if (!run) return null;
+					if (run.status === "processing") {
+						const graph = ["retrying", "processing"].includes(run.graphStatus);
+						const summarize = ["retrying", "processing"].includes(
+							run.summarizeStatus,
+						);
+						return graph || summarize
+							? {
+									...run,
+									graph,
+									summarize,
+									deduplicated: true,
+									stageStarted:
+										run.graphStatus === "processing" ||
+										run.summarizeStatus === "processing",
+								}
+							: null;
+					}
+					if (run.status !== "ready_with_warnings") return null;
 					const plan = planWarningStageRetry(run);
 					if (!plan) return null;
 					const { graph, summarize } = plan;
@@ -1180,26 +1203,44 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 							updatedAt: new Date(),
 						})
 						.where(eq(documentPipelineRuns.generationId, run.generationId));
-					return { ...run, graph, summarize };
+					return {
+						...run,
+						graph,
+						summarize,
+						deduplicated: false,
+						stageStarted: false,
+					};
 				});
 				if (!retry) {
 					set.status = 409;
 					return { error: "No retryable warning stages" };
 				}
-				claimed = retry;
+				if (!retry.deduplicated) claimed = retry;
 				const stage = retry.graph ? "graph" : "summarize";
-				for (const [queuedStage, jobId] of [
-					[
-						"graph",
-						JOB_IDS.graph(retry.generationId, retry.workspaceId ?? undefined),
-					],
-					[
-						"summarize",
-						JOB_IDS.summarize(
-							retry.generationId,
-							retry.workspaceId ?? undefined,
-						),
-					],
+				const retryJobId = warningRetryJobId(stage, retry.generationId);
+				const staleJobs = [
+					...(retry.graph
+						? [
+								[
+									"graph",
+									JOB_IDS.graph(
+										retry.generationId,
+										retry.workspaceId ?? undefined,
+									),
+								] as const,
+							]
+						: []),
+					...(retry.summarize
+						? [
+								[
+									"summarize",
+									JOB_IDS.summarize(
+										retry.generationId,
+										retry.workspaceId ?? undefined,
+									),
+								] as const,
+							]
+						: []),
 					[
 						"finalize",
 						JOB_IDS.finalize(
@@ -1207,14 +1248,45 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 							retry.workspaceId ?? undefined,
 						),
 					],
-				] as const) {
-					const oldJob = await getPipelineQueue(
-						queuedStage,
-						config.REDIS_URL,
-					).getJob(jobId);
-					await oldJob?.remove();
+				] as const;
+				if (!retry.deduplicated) {
+					for (const [queuedStage, jobId] of staleJobs) {
+						const oldJob = await getPipelineQueue(
+							queuedStage,
+							config.REDIS_URL,
+						).getJob(jobId);
+						await oldJob?.remove();
+					}
 				}
 				const queue = getPipelineQueue(stage, config.REDIS_URL);
+				const existingRetryJob = await queue.getJob(retryJobId);
+				if (retry.deduplicated) {
+					const activeRetry = resolveActiveWarningRetry(
+						retry.stageStarted,
+						Boolean(existingRetryJob),
+					);
+					if (activeRetry === "conflict") {
+						set.status = 409;
+						return { error: "No retryable warning stages" };
+					}
+					if (activeRetry === "deduplicate")
+						return {
+							documentId,
+							generationId: retry.generationId,
+							deduplicated: true,
+							retriedStages: [
+								...(retry.graph ? (["graph"] as const) : []),
+								...(retry.summarize ? (["summarize"] as const) : []),
+							],
+						};
+				}
+				const existingRetryState = await existingRetryJob?.getState();
+				if (
+					existingRetryState === "completed" ||
+					existingRetryState === "failed"
+				) {
+					await existingRetryJob?.remove();
+				}
 				const data: PipelineJob = {
 					schemaVersion: PIPELINE_SCHEMA_VERSION,
 					stage,
@@ -1230,15 +1302,17 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 					...(retry.embeddingContextHash
 						? { embeddingContextHash: retry.embeddingContextHash }
 						: {}),
+					warningRetry: true,
 				};
 				await queue.add(stage, data, {
 					...DEFAULT_JOB_OPTIONS,
-					jobId: `${stage}-warning-retry-${retry.generationId}-${Date.now()}`,
+					jobId: retryJobId,
 					priority: SOURCE_PRIORITY.api,
 				});
 				return {
 					documentId,
 					generationId: retry.generationId,
+					deduplicated: retry.deduplicated,
 					retriedStages: [
 						...(retry.graph ? (["graph"] as const) : []),
 						...(retry.summarize ? (["summarize"] as const) : []),

--- a/backend/src/api/routes/documents.ts
+++ b/backend/src/api/routes/documents.ts
@@ -77,6 +77,7 @@ import {
 	rewriteDuplicateAttachmentReferences,
 } from "../../lib/duplicate-attachments";
 import { logger } from "../../lib/logger";
+import { isRetryablePipelineError } from "../../lib/pipeline-error";
 import {
 	dispatchMetadataReembedOutbox,
 	enqueueReembed,
@@ -91,7 +92,15 @@ import { BUCKET, storage } from "../../lib/storage";
 import { acquireTenantTopologyLock } from "../../lib/topology-serialization";
 import { maybePruneVersions } from "../../lib/version-prune";
 import { withTenant } from "../../lib/with-tenant";
+import {
+	JOB_IDS,
+	PIPELINE_SCHEMA_VERSION,
+	type PipelineJob,
+} from "../../queue/contracts";
 import { enqueueDocumentPipeline } from "../../queue/enqueue";
+import { DEFAULT_JOB_OPTIONS, SOURCE_PRIORITY } from "../../queue/names";
+import { planWarningStageRetry } from "../../queue/pipeline-warning-retry";
+import { getPipelineQueue } from "../../queue/queues";
 import {
 	documentRateLimiter,
 	rateLimitHeaders,
@@ -970,6 +979,8 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 						embedStatus: documentPipelineRuns.embedStatus,
 						graphStatus: documentPipelineRuns.graphStatus,
 						summarizeStatus: documentPipelineRuns.summarizeStatus,
+						graphErrorCode: documentPipelineRuns.graphErrorCode,
+						summarizeErrorCode: documentPipelineRuns.summarizeErrorCode,
 						finalizeStatus: documentPipelineRuns.finalizeStatus,
 						totalBatches: documentPipelineRuns.totalBatches,
 						completedBatches: documentPipelineRuns.completedBatches,
@@ -1024,6 +1035,30 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 					completed: run.completedBatches,
 					failed: run.failedBatches,
 				},
+				warnings: [
+					...(run.graphStatus === "failed"
+						? [
+								{
+									stage: "graph" as const,
+									code: run.graphErrorCode ?? "graph_failed",
+									retryable: isRetryablePipelineError(
+										run.graphErrorCode ?? "graph_failed",
+									),
+								},
+							]
+						: []),
+					...(run.summarizeStatus === "failed"
+						? [
+								{
+									stage: "summarize" as const,
+									code: run.summarizeErrorCode ?? "summary_failed",
+									retryable: isRetryablePipelineError(
+										run.summarizeErrorCode ?? "summary_failed",
+									),
+								},
+							]
+						: []),
+				],
 				updatedAt: run.updatedAt,
 			};
 		} catch (err) {
@@ -1035,6 +1070,202 @@ export const documentRoutes = new Elysia({ prefix: "/api" })
 			return { error: "Failed to load pipeline progress" };
 		}
 	})
+	.post(
+		"/documents/:id/pipeline/retry-warnings",
+		async ({ params, set, request }) => {
+			const access = await resolveContentAccess(request);
+			const ctx = access.ctx;
+			if (ctx.role === "none") {
+				set.status = 401;
+				return { error: "Unauthorized" };
+			}
+			if (!canAccessContent(access, "write")) {
+				set.status = 403;
+				return { error: "Forbidden" };
+			}
+			let claimed:
+				| { generationId: string; graph: boolean; summarize: boolean }
+				| undefined;
+			try {
+				const retry = await withTenant(ctx, async (tx) => {
+					await acquireDocumentPipelineLock(tx, params.id);
+					const [run] = await tx
+						.select({
+							generationId: documentPipelineRuns.generationId,
+							revision: documentPipelineRuns.revision,
+							ownerId: documentPipelineRuns.ownerId,
+							workspaceId: documentPipelineRuns.workspaceId,
+							refreshMode: documentPipelineRuns.refreshMode,
+							embeddingContextHash: documentPipelineRuns.embeddingContextHash,
+							embedStatus: documentPipelineRuns.embedStatus,
+							graphStatus: documentPipelineRuns.graphStatus,
+							summarizeStatus: documentPipelineRuns.summarizeStatus,
+							graphErrorCode: documentPipelineRuns.graphErrorCode,
+							summarizeErrorCode: documentPipelineRuns.summarizeErrorCode,
+						})
+						.from(documentPipelineRuns)
+						.innerJoin(
+							documents,
+							and(
+								eq(documents.id, documentPipelineRuns.documentId),
+								eq(
+									documents.activeEmbeddingGeneration,
+									documentPipelineRuns.generationId,
+								),
+							),
+						)
+						.where(
+							and(
+								eq(documentPipelineRuns.documentId, params.id),
+								eq(documentPipelineRuns.ownerId, ctx.userId),
+								eq(documentPipelineRuns.status, "ready_with_warnings"),
+								eq(documentPipelineRuns.embedStatus, "ready"),
+								isNull(documents.deletedAt),
+								...(access.restricted
+									? [
+											access.categoryId
+												? effectiveDocumentCategoryCondition(
+														documents.categoryId,
+														documents.folderId,
+														ctx,
+														access.categoryId,
+													)
+												: sql`false`,
+										]
+									: []),
+							),
+						)
+						.orderBy(desc(documentPipelineRuns.updatedAt))
+						.limit(1)
+						.for("update");
+					if (!run) return null;
+					const plan = planWarningStageRetry(run);
+					if (!plan) return null;
+					const { graph, summarize } = plan;
+					await tx
+						.update(documentPipelineRuns)
+						.set({
+							status: "processing",
+							finalizeStatus: "pending",
+							...(graph
+								? { graphStatus: "retrying" as const, graphErrorCode: null }
+								: {}),
+							...(summarize
+								? {
+										summarizeStatus: "retrying" as const,
+										summarizeErrorCode: null,
+									}
+								: {}),
+							updatedAt: new Date(),
+						})
+						.where(eq(documentPipelineRuns.generationId, run.generationId));
+					return { ...run, graph, summarize };
+				});
+				if (!retry) {
+					set.status = 409;
+					return { error: "No retryable warning stages" };
+				}
+				claimed = retry;
+				const stage = retry.graph ? "graph" : "summarize";
+				for (const [queuedStage, jobId] of [
+					[
+						"graph",
+						JOB_IDS.graph(retry.generationId, retry.workspaceId ?? undefined),
+					],
+					[
+						"summarize",
+						JOB_IDS.summarize(
+							retry.generationId,
+							retry.workspaceId ?? undefined,
+						),
+					],
+					[
+						"finalize",
+						JOB_IDS.finalize(
+							retry.generationId,
+							retry.workspaceId ?? undefined,
+						),
+					],
+				] as const) {
+					const oldJob = await getPipelineQueue(
+						queuedStage,
+						config.REDIS_URL,
+					).getJob(jobId);
+					await oldJob?.remove();
+				}
+				const queue = getPipelineQueue(stage, config.REDIS_URL);
+				const data: PipelineJob = {
+					schemaVersion: PIPELINE_SCHEMA_VERSION,
+					stage,
+					documentId: params.id,
+					ownerId: retry.ownerId,
+					...(retry.workspaceId ? { workspaceId: retry.workspaceId } : {}),
+					generationId: retry.generationId,
+					revision: retry.revision,
+					requestedAt: new Date().toISOString(),
+					source: "api",
+					refreshMode:
+						retry.refreshMode === "incremental" ? "incremental" : "full",
+					...(retry.embeddingContextHash
+						? { embeddingContextHash: retry.embeddingContextHash }
+						: {}),
+				};
+				await queue.add(stage, data, {
+					...DEFAULT_JOB_OPTIONS,
+					jobId: `${stage}-warning-retry-${retry.generationId}-${Date.now()}`,
+					priority: SOURCE_PRIORITY.api,
+				});
+				return {
+					documentId: params.id,
+					generationId: retry.generationId,
+					retriedStages: [
+						...(retry.graph ? (["graph"] as const) : []),
+						...(retry.summarize ? (["summarize"] as const) : []),
+					],
+				};
+			} catch (err) {
+				const failedClaim = claimed;
+				if (failedClaim) {
+					await withTenant(ctx, (tx) =>
+						tx
+							.update(documentPipelineRuns)
+							.set({
+								status: "ready_with_warnings",
+								finalizeStatus: "ready",
+								...(failedClaim.graph
+									? {
+											graphStatus: "failed" as const,
+											graphErrorCode: "queue_enqueue_failed",
+										}
+									: {}),
+								...(failedClaim.summarize
+									? {
+											summarizeStatus: "failed" as const,
+											summarizeErrorCode: "queue_enqueue_failed",
+										}
+									: {}),
+								updatedAt: new Date(),
+							})
+							.where(
+								and(
+									eq(
+										documentPipelineRuns.generationId,
+										failedClaim.generationId,
+									),
+									eq(documentPipelineRuns.status, "processing"),
+								),
+							),
+					).catch(() => undefined);
+				}
+				logger.error(
+					{ err, documentId: params.id },
+					"Failed to retry warning stages",
+				);
+				set.status = 500;
+				return { error: "Failed to retry warning stages" };
+			}
+		},
+	)
 	.get("/documents/:id/knowledge-summary", async ({ params, set, request }) => {
 		const parsedParams = documentIdParamsSchema.safeParse(params);
 		if (!parsedParams.success) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -173,7 +173,7 @@ const swaggerConfig = {
 		},
 		info: {
 			title: "DocsMint API",
-			version: "0.8.1",
+			version: "0.8.2",
 			description:
 				"Self-hosted AI-native knowledge workspace and installable PWA with hybrid search, GraphRAG, REST, SDK, CLI, and MCP access for people and AI agents.",
 			contact: { name: "HiAi-gg", url: "https://github.com/HiAi-gg/docsmint" },

--- a/backend/src/lib/graph/extract-entities.ts
+++ b/backend/src/lib/graph/extract-entities.ts
@@ -24,7 +24,7 @@ import { documentPipelineLockKey } from "../document-pipeline-serialization";
 import { logger } from "../logger";
 import {
 	type ChatProviderConfig,
-	requestStructuredChat,
+	requestStructuredChatDetailed,
 	resolveChatProviderKey,
 	uniqueChatProviders,
 } from "../openai-compatible-chat";
@@ -326,7 +326,14 @@ export async function extractEntities(
 				{ err, documentId },
 				"Entity extraction LLM call failed — skipping",
 			);
-			return { status: "failed", warning: "provider_failed", entities: [] };
+			return {
+				status: "failed",
+				warning:
+					err instanceof Error && err.message
+						? err.message
+						: "provider_failure",
+				entities: [],
+			};
 		}
 	}
 	if (entities === null) {
@@ -472,7 +479,7 @@ async function callEntityExtractionLLM(
 	const [primary, ...fallbacks] = providers;
 	if (!primary) return null;
 
-	const result = await requestStructuredChat({
+	const attempt = await requestStructuredChatDetailed({
 		primary,
 		fallbacks,
 		messages: [
@@ -483,7 +490,8 @@ async function callEntityExtractionLLM(
 		maxTokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
 		temperature: options.temperature ?? DEFAULT_TEMPERATURE,
 	});
-	return result ? parseExtractionResponse(JSON.stringify(result.data)) : null;
+	if (!attempt.ok) throw attempt.error;
+	return parseExtractionResponse(JSON.stringify(attempt.result.data));
 }
 
 /**

--- a/backend/src/lib/knowledge-summary-provider.ts
+++ b/backend/src/lib/knowledge-summary-provider.ts
@@ -6,7 +6,7 @@ import type {
 } from "./knowledge-summary";
 import {
 	type ChatProviderConfig,
-	requestStructuredChat,
+	requestStructuredChatDetailed,
 	resolveChatProviderKey,
 } from "./openai-compatible-chat";
 
@@ -59,7 +59,7 @@ export async function requestKnowledgeSummary(
 			config.GRAPH_EXTRACT_FALLBACK_2_MODEL,
 		),
 	].filter((item): item is NonNullable<typeof item> => Boolean(item));
-	const result = await requestStructuredChat({
+	const attempt = await requestStructuredChatDetailed({
 		primary,
 		fallbacks,
 		messages: [
@@ -73,5 +73,6 @@ export async function requestKnowledgeSummary(
 		maxTokens: 768,
 		temperature: 0,
 	});
-	return result ? { ...result.data, model: result.model } : null;
+	if (!attempt.ok) throw attempt.error;
+	return { ...attempt.result.data, model: attempt.result.model };
 }

--- a/backend/src/lib/knowledge-summary.ts
+++ b/backend/src/lib/knowledge-summary.ts
@@ -37,10 +37,11 @@ export async function buildKnowledgeSummary(
 		return { status: "skipped", reason: "empty_document" };
 	}
 	const output = await provider(document);
-	if (!output) throw new Error("summary_provider_failed");
+	if (!output) throw new Error("provider_failure");
 	const language = output.language.trim();
 	const description = output.description.trim();
-	if (!language || !description) throw new Error("summary_provider_invalid");
+	if (!language || !description)
+		throw new Error("permanent_validation_failure");
 	const seen = new Set<string>();
 	const keywords: string[] = [];
 	for (const raw of output.keywords) {

--- a/backend/src/lib/openai-compatible-chat.ts
+++ b/backend/src/lib/openai-compatible-chat.ts
@@ -127,7 +127,7 @@ export async function requestStructuredChatDetailed<T>(
 			};
 		} catch (error) {
 			lastError =
-				error instanceof DOMException && error.name === "AbortError"
+				error instanceof Error && error.name === "AbortError"
 					? new PipelineProviderError("provider_timeout", true)
 					: new PipelineProviderError("provider_failure", true);
 			// Expansion and extraction are enrichment. Continue with the next

--- a/backend/src/lib/openai-compatible-chat.ts
+++ b/backend/src/lib/openai-compatible-chat.ts
@@ -96,8 +96,8 @@ export async function requestStructuredChatDetailed<T>(
 		...(options.fallbacks ?? []),
 	]);
 	let lastError = new PipelineProviderError(
-		"provider_failure",
-		true,
+		"provider_unavailable",
+		false,
 		"No chat provider was configured",
 	);
 	for (const provider of providers) {
@@ -127,9 +127,11 @@ export async function requestStructuredChatDetailed<T>(
 			};
 		} catch (error) {
 			lastError =
-				error instanceof Error && error.name === "AbortError"
-					? new PipelineProviderError("provider_timeout", true)
-					: new PipelineProviderError("provider_failure", true);
+				error instanceof PipelineProviderError
+					? error
+					: error instanceof Error && error.name === "AbortError"
+						? new PipelineProviderError("provider_timeout", true)
+						: new PipelineProviderError("provider_failure", true);
 			// Expansion and extraction are enrichment. Continue with the next
 			// provider and let callers degrade gracefully when the chain fails.
 		}
@@ -165,13 +167,22 @@ async function requestChatContent<T>(
 			}),
 		});
 		if (!response.ok)
-			throw new Error(`chat provider returned ${response.status}`);
-		const body = (await response.json()) as {
+			throw new PipelineProviderError(
+				"provider_failure",
+				true,
+				`chat provider returned ${response.status}`,
+			);
+		let body: {
 			choices?: Array<{ message?: { content?: unknown } }>;
 		};
+		try {
+			body = (await response.json()) as typeof body;
+		} catch {
+			throw new PipelineProviderError("invalid_provider_response", true);
+		}
 		const content = body.choices?.[0]?.message?.content;
 		if (typeof content !== "string" || !content.trim()) {
-			throw new Error("chat provider returned empty content");
+			throw new PipelineProviderError("invalid_provider_response", true);
 		}
 		return content;
 	} finally {

--- a/backend/src/lib/openai-compatible-chat.ts
+++ b/backend/src/lib/openai-compatible-chat.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import { PipelineProviderError } from "./pipeline-error";
 
 export interface ChatProviderConfig {
 	baseUrl: string;
@@ -27,6 +28,10 @@ export interface StructuredChatResult<T> {
 	data: T;
 	model: string;
 }
+
+export type StructuredChatAttempt<T> =
+	| { ok: true; result: StructuredChatResult<T> }
+	| { ok: false; error: PipelineProviderError };
 
 /**
  * Resolve a provider credential without allowing a shared OpenRouter key to
@@ -78,24 +83,58 @@ export function uniqueChatProviders(
 export async function requestStructuredChat<T>(
 	options: StructuredChatOptions<T>,
 ): Promise<StructuredChatResult<T> | null> {
+	const attempt = await requestStructuredChatDetailed(options);
+	return attempt.ok ? attempt.result : null;
+}
+
+export async function requestStructuredChatDetailed<T>(
+	options: StructuredChatOptions<T>,
+): Promise<StructuredChatAttempt<T>> {
 	const providers = uniqueChatProviders([
 		options.primary,
 		options.fallback,
 		...(options.fallbacks ?? []),
 	]);
+	let lastError = new PipelineProviderError(
+		"provider_failure",
+		true,
+		"No chat provider was configured",
+	);
 	for (const provider of providers) {
 		try {
 			const raw = await requestChatContent(provider, options);
-			const parsed = parseJson(raw);
+			let parsed: unknown;
+			try {
+				parsed = parseJson(raw);
+			} catch {
+				lastError = new PipelineProviderError(
+					"invalid_provider_response",
+					true,
+				);
+				continue;
+			}
 			const result = options.outputSchema.safeParse(parsed);
-			if (!result.success) continue;
-			return { data: result.data, model: provider.model };
-		} catch {
+			if (!result.success) {
+				lastError = new PipelineProviderError(
+					"permanent_validation_failure",
+					false,
+				);
+				continue;
+			}
+			return {
+				ok: true,
+				result: { data: result.data, model: provider.model },
+			};
+		} catch (error) {
+			lastError =
+				error instanceof DOMException && error.name === "AbortError"
+					? new PipelineProviderError("provider_timeout", true)
+					: new PipelineProviderError("provider_failure", true);
 			// Expansion and extraction are enrichment. Continue with the next
 			// provider and let callers degrade gracefully when the chain fails.
 		}
 	}
-	return null;
+	return { ok: false, error: lastError };
 }
 
 async function requestChatContent<T>(

--- a/backend/src/lib/pipeline-error.ts
+++ b/backend/src/lib/pipeline-error.ts
@@ -2,7 +2,8 @@ export type PipelineProviderErrorCode =
 	| "provider_failure"
 	| "provider_timeout"
 	| "invalid_provider_response"
-	| "permanent_validation_failure";
+	| "permanent_validation_failure"
+	| "provider_unavailable";
 
 export class PipelineProviderError extends Error {
 	constructor(
@@ -17,10 +18,16 @@ export class PipelineProviderError extends Error {
 
 export function pipelineErrorCode(error: unknown, fallback: string): string {
 	if (error instanceof PipelineProviderError) return error.code;
-	if (error instanceof Error && error.message.trim()) return error.message;
 	return fallback;
 }
 
 export function isRetryablePipelineError(code: string): boolean {
-	return code !== "permanent_validation_failure";
+	return new Set([
+		"provider_failure",
+		"provider_timeout",
+		"invalid_provider_response",
+		"queue_enqueue_failed",
+		"age_unavailable",
+		"age_persist_failed",
+	]).has(code);
 }

--- a/backend/src/lib/pipeline-error.ts
+++ b/backend/src/lib/pipeline-error.ts
@@ -1,0 +1,26 @@
+export type PipelineProviderErrorCode =
+	| "provider_failure"
+	| "provider_timeout"
+	| "invalid_provider_response"
+	| "permanent_validation_failure";
+
+export class PipelineProviderError extends Error {
+	constructor(
+		public readonly code: PipelineProviderErrorCode,
+		public readonly retryable: boolean,
+		message: string = code,
+	) {
+		super(message);
+		this.name = "PipelineProviderError";
+	}
+}
+
+export function pipelineErrorCode(error: unknown, fallback: string): string {
+	if (error instanceof PipelineProviderError) return error.code;
+	if (error instanceof Error && error.message.trim()) return error.message;
+	return fallback;
+}
+
+export function isRetryablePipelineError(code: string): boolean {
+	return code !== "permanent_validation_failure";
+}

--- a/backend/src/queue/adapters.ts
+++ b/backend/src/queue/adapters.ts
@@ -284,6 +284,17 @@ function stagePatch(stage: PipelineStage, status: PipelineStageStatus) {
 	return { finalizeStatus: status };
 }
 
+function stageErrorPatch(
+	stage: PipelineStage,
+	status: PipelineStageStatus,
+	errorCode?: string,
+) {
+	const value = status === "failed" ? (errorCode ?? "unknown_failure") : null;
+	if (stage === "graph") return { graphErrorCode: value };
+	if (stage === "summarize") return { summarizeErrorCode: value };
+	return {};
+}
+
 function pipelineStageStatus(value: string): PipelineStageStatus {
 	return value === "ready_with_warnings"
 		? "failed"
@@ -380,6 +391,7 @@ async function setStageStatus(
 			.update(documentPipelineRuns)
 			.set({
 				...stagePatch(stage, status),
+				...stageErrorPatch(stage, status, errorCode),
 				...(errorCode ? { errorCode } : {}),
 				updatedAt: new Date(),
 			})
@@ -944,6 +956,7 @@ export function createPipelineStageDependencies(
 							revision: run.revision,
 							embeddingContextHash: run.embeddingContextHash ?? undefined,
 							embedStatus: pipelineStageStatus(run.embedStatus),
+							summarizeStatus: pipelineStageStatus(run.summarizeStatus),
 						}
 					: null;
 			},
@@ -1016,6 +1029,14 @@ export function createPipelineStageDependencies(
 				await enqueueIfActive("summarize", "summarize", data, {
 					...DEFAULT_JOB_OPTIONS,
 					jobId: JOB_IDS.summarize(job.generationId, job.workspaceId),
+					priority: SOURCE_PRIORITY[job.source],
+				});
+			},
+			async enqueueFinalize(job) {
+				const data: PipelineJob = { ...job, stage: "finalize" };
+				await enqueueIfActive("finalize", "finalize", data, {
+					...DEFAULT_JOB_OPTIONS,
+					jobId: `${JOB_IDS.finalize(job.generationId, job.workspaceId)}-graph-retry-${job.requestedAt.replace(/\D/g, "")}`,
 					priority: SOURCE_PRIORITY[job.source],
 				});
 			},

--- a/backend/src/queue/adapters.ts
+++ b/backend/src/queue/adapters.ts
@@ -39,6 +39,7 @@ import type {
 import { JOB_IDS, PIPELINE_SCHEMA_VERSION } from "./contracts";
 import { resolveDocumentRevision } from "./document-revision";
 import { DEFAULT_JOB_OPTIONS, SOURCE_PRIORITY } from "./names";
+import { summaryJobIdForPipeline } from "./pipeline-warning-retry";
 import {
 	type ProviderLimiterProfile,
 	withProviderPermit,
@@ -1028,7 +1029,7 @@ export function createPipelineStageDependencies(
 				const data: PipelineJob = { ...job, stage: "summarize" };
 				await enqueueIfActive("summarize", "summarize", data, {
 					...DEFAULT_JOB_OPTIONS,
-					jobId: JOB_IDS.summarize(job.generationId, job.workspaceId),
+					jobId: summaryJobIdForPipeline(job),
 					priority: SOURCE_PRIORITY[job.source],
 				});
 			},

--- a/backend/src/queue/contracts.ts
+++ b/backend/src/queue/contracts.ts
@@ -26,6 +26,7 @@ const basePipelineJobFields = {
 	source: pipelineSourceSchema,
 	refreshMode: pipelineRefreshModeSchema,
 	embeddingContextHash: z.string().min(1).optional(),
+	warningRetry: z.literal(true).optional(),
 } as const;
 
 function normalizeLegacyPipelineJob(value: unknown): unknown {

--- a/backend/src/queue/pipeline-warning-retry.ts
+++ b/backend/src/queue/pipeline-warning-retry.ts
@@ -1,0 +1,22 @@
+import { isRetryablePipelineError } from "../lib/pipeline-error";
+export interface WarningStageState {
+	graphStatus: string;
+	summarizeStatus: string;
+	graphErrorCode: string | null;
+	summarizeErrorCode: string | null;
+}
+
+export function planWarningStageRetry(state: WarningStageState): {
+	graph: boolean;
+	summarize: boolean;
+	entryStage: "graph" | "summarize";
+} | null {
+	const graph =
+		state.graphStatus === "failed" &&
+		isRetryablePipelineError(state.graphErrorCode ?? "graph_failed");
+	const summarize =
+		state.summarizeStatus === "failed" &&
+		isRetryablePipelineError(state.summarizeErrorCode ?? "summary_failed");
+	if (!graph && !summarize) return null;
+	return { graph, summarize, entryStage: graph ? "graph" : "summarize" };
+}

--- a/backend/src/queue/pipeline-warning-retry.ts
+++ b/backend/src/queue/pipeline-warning-retry.ts
@@ -1,9 +1,35 @@
 import { isRetryablePipelineError } from "../lib/pipeline-error";
+import { JOB_IDS } from "./contracts";
 export interface WarningStageState {
 	graphStatus: string;
 	summarizeStatus: string;
 	graphErrorCode: string | null;
 	summarizeErrorCode: string | null;
+}
+
+export function resolveActiveWarningRetry(
+	stageStarted: boolean,
+	retryJobExists: boolean,
+): "enqueue" | "deduplicate" | "conflict" {
+	if (!stageStarted) return "enqueue";
+	return retryJobExists ? "deduplicate" : "conflict";
+}
+
+export function warningRetryJobId(
+	stage: "graph" | "summarize",
+	generationId: string,
+): string {
+	return `${stage}-warning-retry-${generationId}`;
+}
+
+export function summaryJobIdForPipeline(job: {
+	generationId: string;
+	workspaceId?: string;
+	warningRetry?: true;
+}): string {
+	return job.warningRetry
+		? warningRetryJobId("summarize", job.generationId)
+		: JOB_IDS.summarize(job.generationId, job.workspaceId);
 }
 
 export function planWarningStageRetry(state: WarningStageState): {

--- a/backend/src/queue/stage-policies.ts
+++ b/backend/src/queue/stage-policies.ts
@@ -1,4 +1,8 @@
 import { isStaleRevisionError } from "../lib/graph/generation-state";
+import {
+	PipelineProviderError,
+	pipelineErrorCode,
+} from "../lib/pipeline-error";
 
 export type PipelineStageStatus =
 	| "pending"
@@ -162,10 +166,11 @@ export async function processSummaryStage<TJob extends PipelineJobIdentity>(
 		await dependencies.setSummaryStatus(
 			job.generationId,
 			"failed",
-			error instanceof Error ? error.name : "summary_failed",
+			pipelineErrorCode(error, "summary_failed"),
 		);
 		if (!(await continueIfCurrent())) return;
 		await dependencies.enqueueFinalize(job);
+		if (error instanceof PipelineProviderError && error.retryable) throw error;
 		return;
 	}
 	if (!(await continueIfCurrent())) return;
@@ -205,7 +210,7 @@ export async function processGraphStageFailure<
 	await dependencies.setGraphStatus(
 		job.generationId,
 		"failed",
-		error instanceof Error ? error.name : "graph_failed",
+		pipelineErrorCode(error, "graph_failed"),
 	);
 	if (!(await dependencies.isCancelled?.(job))) {
 		await dependencies.enqueueSummarize(job);

--- a/backend/src/queue/workers/graph.worker.ts
+++ b/backend/src/queue/workers/graph.worker.ts
@@ -147,6 +147,12 @@ export function createGraphWorker(deps: GraphWorkerDependencies) {
 			await deps.setGraphStatus(job.generationId, "ready");
 			await continuePipeline();
 		} catch (error) {
+			if (error instanceof PipelineProviderError) {
+				await deps.setGraphStatus(job.generationId, "failed", error.code);
+				await continuePipeline();
+				if (error.retryable) throw error;
+				return;
+			}
 			await processGraphStageFailure(job, error, deps);
 		}
 	};

--- a/backend/src/queue/workers/graph.worker.ts
+++ b/backend/src/queue/workers/graph.worker.ts
@@ -1,3 +1,4 @@
+import { PipelineProviderError } from "../../lib/pipeline-error";
 import { graphJobSchema, type PipelineJob } from "../contracts";
 import { processGraphStageFailure } from "../stage-policies";
 
@@ -17,6 +18,7 @@ export interface GraphPipelineState {
 	revision: string;
 	embeddingContextHash?: string;
 	embedStatus: PipelineStageStatus;
+	summarizeStatus?: PipelineStageStatus;
 }
 
 export type GraphStageOutcome =
@@ -44,6 +46,7 @@ export interface GraphWorkerDependencies {
 		errorCode?: string,
 	): Promise<void>;
 	enqueueSummarize(job: ReturnType<typeof graphJobSchema.parse>): Promise<void>;
+	enqueueFinalize?(job: ReturnType<typeof graphJobSchema.parse>): Promise<void>;
 }
 
 /**
@@ -56,6 +59,18 @@ export function createGraphWorker(deps: GraphWorkerDependencies) {
 		if (await deps.isCancelled?.(job)) return;
 		const run = await deps.getRun(job);
 		if (!run) throw new Error("Pipeline run not found");
+		const continuePipeline = async () => {
+			if (await deps.isCancelled?.(job)) return;
+			if (
+				run.summarizeStatus === "ready" ||
+				run.summarizeStatus === "skipped"
+			) {
+				if (deps.enqueueFinalize) await deps.enqueueFinalize(job);
+				else await deps.enqueueSummarize(job);
+				return;
+			}
+			await deps.enqueueSummarize(job);
+		};
 		if (run.ownerId !== job.ownerId || run.documentId !== job.documentId) {
 			throw new Error("Pipeline owner mismatch");
 		}
@@ -86,7 +101,7 @@ export function createGraphWorker(deps: GraphWorkerDependencies) {
 				"skipped",
 				"embedding_not_ready",
 			);
-			if (!(await deps.isCancelled?.(job))) await deps.enqueueSummarize(job);
+			await continuePipeline();
 			return;
 		}
 
@@ -109,12 +124,28 @@ export function createGraphWorker(deps: GraphWorkerDependencies) {
 				return;
 			}
 			if (outcome.status === "unavailable" || outcome.status === "failed") {
+				if (
+					outcome.status === "failed" &&
+					[
+						"provider_failure",
+						"provider_timeout",
+						"invalid_provider_response",
+					].includes(outcome.warning)
+				) {
+					throw new PipelineProviderError(
+						outcome.warning as
+							| "provider_failure"
+							| "provider_timeout"
+							| "invalid_provider_response",
+						true,
+					);
+				}
 				await deps.setGraphStatus(job.generationId, "failed", outcome.warning);
-				if (!(await deps.isCancelled?.(job))) await deps.enqueueSummarize(job);
+				await continuePipeline();
 				return;
 			}
 			await deps.setGraphStatus(job.generationId, "ready");
-			if (!(await deps.isCancelled?.(job))) await deps.enqueueSummarize(job);
+			await continuePipeline();
 		} catch (error) {
 			await processGraphStageFailure(job, error, deps);
 		}

--- a/backend/src/search/rerank-provider.ts
+++ b/backend/src/search/rerank-provider.ts
@@ -15,6 +15,12 @@ interface RerankSlot {
 	model: string;
 }
 
+interface RerankCandidateRecord {
+	id: string;
+	document: string;
+	originalIndex: number;
+}
+
 function configuredSlots(): RerankSlot[] {
 	const slots: Array<{
 		baseUrl?: string;
@@ -69,25 +75,28 @@ function rerankUrl(baseUrl: string): string {
 export async function requestRerank(
 	input: RerankRequest,
 ): Promise<RerankProviderResult | null> {
-	const documents = input.candidates
-		.map((candidate) => candidate.text.trim())
-		.filter((text) => text.length > 0);
-	if (documents.length === 0) return null;
-	const ids = input.candidates.map((candidate) => candidate.id);
+	const candidates = input.candidates
+		.map((candidate, originalIndex) => ({
+			id: candidate.id,
+			document: candidate.text.trim(),
+			originalIndex,
+		}))
+		.filter((candidate) => candidate.document.length > 0);
+	if (candidates.length === 0) return null;
 	const topN = Math.min(
 		input.topN ?? config.SEARCH_RERANK_TOP_N,
-		documents.length,
+		candidates.length,
 	);
 	const timeoutMs = config.SEARCH_RERANK_TIMEOUT_MS;
 	const started = performance.now();
 	incrementCounterBy(
 		METRIC_NAMES.SEARCH_RERANK_CANDIDATES_TOTAL,
-		documents.length,
+		candidates.length,
 	);
 	try {
 		for (const slot of configuredSlots()) {
 			try {
-				const hits = await callRerankSlot(slot, input.query, documents, ids, {
+				const hits = await callRerankSlot(slot, input.query, candidates, {
 					topN,
 					timeoutMs,
 				});
@@ -114,8 +123,7 @@ export async function requestRerank(
 async function callRerankSlot(
 	slot: RerankSlot,
 	query: string,
-	documents: string[],
-	ids: string[],
+	candidates: RerankCandidateRecord[],
 	options: { topN: number; timeoutMs: number },
 ): Promise<RerankHit[]> {
 	const controller = new AbortController();
@@ -132,7 +140,7 @@ async function callRerankSlot(
 			body: JSON.stringify({
 				model: slot.model,
 				query,
-				documents,
+				documents: candidates.map((candidate) => candidate.document),
 				top_n: options.topN,
 			}),
 		});
@@ -143,16 +151,23 @@ async function callRerankSlot(
 			results?: Array<{ index?: number; relevance_score?: number }>;
 		};
 		const hits: RerankHit[] = [];
+		const seenIds = new Set<string>();
 		for (const [rank, row] of (body.results ?? []).entries()) {
-			if (typeof row.index !== "number" || row.index < 0) continue;
-			const id = ids[row.index];
-			if (!id) continue;
+			if (
+				typeof row.index !== "number" ||
+				!Number.isInteger(row.index) ||
+				row.index < 0
+			)
+				continue;
+			const candidate = candidates[row.index];
+			if (!candidate || seenIds.has(candidate.id)) continue;
+			seenIds.add(candidate.id);
 			const score =
 				typeof row.relevance_score === "number" &&
 				Number.isFinite(row.relevance_score)
 					? row.relevance_score
 					: 0;
-			hits.push({ id, score, rank: rank + 1 });
+			hits.push({ id: candidate.id, score, rank: rank + 1 });
 		}
 		return hits;
 	} finally {

--- a/backend/tests/integration/routes.documents.test.ts
+++ b/backend/tests/integration/routes.documents.test.ts
@@ -11,23 +11,23 @@
  */
 
 import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
 } from "bun:test";
 import {
-  OWNER_ID,
-  OTHER_USER_ID,
-  getState,
-  noAuthHeaders,
-  ownerHeaders,
-  request,
-  resetState,
-  setupHarness,
+	getState,
+	noAuthHeaders,
+	OTHER_USER_ID,
+	OWNER_ID,
+	ownerHeaders,
+	request,
+	resetState,
+	setupHarness,
 } from "./_harness";
 
 // The harness's `sql` mock returns plain `{ [Symbol(sql)]: true }` objects
@@ -37,162 +37,162 @@ import {
 // for the lifetime of this test file and remove it in afterAll so it
 // doesn't leak into other test files.
 (Object.prototype as any).as = function (this: any) {
-  return this;
+	return this;
 };
 
 let app: any;
 
 beforeAll(async () => {
-  const built = await setupHarness();
-  app = built.app;
+	const built = await setupHarness();
+	app = built.app;
 });
 
 afterAll(() => {
-  delete (Object.prototype as any).as;
+	delete (Object.prototype as any).as;
 });
 
 beforeEach(() => {
-  resetState();
+	resetState();
 });
 
 afterEach(() => {
-  resetState();
+	resetState();
 });
 
 function authedGet(path: string) {
-  return request(app, path, { method: "GET", headers: ownerHeaders() });
+	return request(app, path, { method: "GET", headers: ownerHeaders() });
 }
 
 function authedPost(path: string, body: any) {
-  return request(app, path, {
-    method: "POST",
-    headers: ownerHeaders(),
-    body: JSON.stringify(body),
-  });
+	return request(app, path, {
+		method: "POST",
+		headers: ownerHeaders(),
+		body: JSON.stringify(body),
+	});
 }
 
 function authedPatch(path: string, body: any) {
-  return request(app, path, {
-    method: "PATCH",
-    headers: ownerHeaders(),
-    body: JSON.stringify(body),
-  });
+	return request(app, path, {
+		method: "PATCH",
+		headers: ownerHeaders(),
+		body: JSON.stringify(body),
+	});
 }
 
 function authedDelete(path: string) {
-  return request(app, path, { method: "DELETE", headers: ownerHeaders() });
+	return request(app, path, { method: "DELETE", headers: ownerHeaders() });
 }
 
 function seedDocument(overrides: Partial<any> = {}): any {
-  const now = new Date("2024-06-01T00:00:00Z");
-  const doc = {
-    id: "00000000-0000-4000-8000-000000000000",
-    ownerId: OWNER_ID,
-    folderId: null,
-    title: "Seeded Doc",
-    content: "hello world",
-    contentJson: null,
-    metadata: null,
-    createdAt: now,
-    updatedAt: now,
-    ...overrides,
-  };
-  getState().documents.set(doc.id, doc);
-  return doc;
+	const now = new Date("2024-06-01T00:00:00Z");
+	const doc = {
+		id: "00000000-0000-4000-8000-000000000000",
+		ownerId: OWNER_ID,
+		folderId: null,
+		title: "Seeded Doc",
+		content: "hello world",
+		contentJson: null,
+		metadata: null,
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+	getState().documents.set(doc.id, doc);
+	return doc;
 }
 
 describe("GET /api/documents", () => {
-  it("returns 401 without auth", async () => {
-    const res = await request(app, "/api/documents", {
-      method: "GET",
-      headers: noAuthHeaders(),
-    });
-    expect(res.status).toBe(401);
-    expect(res.body).toEqual({ error: "Unauthorized" });
-  });
+	it("returns 401 without auth", async () => {
+		const res = await request(app, "/api/documents", {
+			method: "GET",
+			headers: noAuthHeaders(),
+		});
+		expect(res.status).toBe(401);
+		expect(res.body).toEqual({ error: "Unauthorized" });
+	});
 
-  it("returns 200 with empty items when no documents exist", async () => {
-    const res = await authedGet("/api/documents");
-    expect(res.status).toBe(200);
-    expect((res.body as any).items).toEqual([]);
-    expect((res.body as any).page).toBe(1);
-    expect((res.body as any).limit).toBe(20);
-  });
+	it("returns 200 with empty items when no documents exist", async () => {
+		const res = await authedGet("/api/documents");
+		expect(res.status).toBe(200);
+		expect((res.body as any).items).toEqual([]);
+		expect((res.body as any).page).toBe(1);
+		expect((res.body as any).limit).toBe(20);
+	});
 
-  it("returns only the current user's documents", async () => {
-    seedDocument({
-      id: "11111111-1111-4111-8111-111111111111",
-      title: "Mine A",
-    });
-    seedDocument({
-      id: "22222222-2222-4222-8222-222222222222",
-      title: "Mine B",
-    });
-    seedDocument({
-      id: "33333333-3333-4333-8333-333333333333",
-      title: "Theirs",
-      ownerId: OTHER_USER_ID,
-    });
+	it("returns only the current user's documents", async () => {
+		seedDocument({
+			id: "11111111-1111-4111-8111-111111111111",
+			title: "Mine A",
+		});
+		seedDocument({
+			id: "22222222-2222-4222-8222-222222222222",
+			title: "Mine B",
+		});
+		seedDocument({
+			id: "33333333-3333-4333-8333-333333333333",
+			title: "Theirs",
+			ownerId: OTHER_USER_ID,
+		});
 
-    const res = await authedGet("/api/documents");
-    expect(res.status).toBe(200);
-    const items = (res.body as any).items as Array<{
-      id: string;
-      title: string;
-    }>;
-    const ids = items.map((d) => d.id);
-    expect(ids).toContain("11111111-1111-4111-8111-111111111111");
-    expect(ids).toContain("22222222-2222-4222-8222-222222222222");
-    expect(ids).not.toContain("33333333-3333-4333-8333-333333333333");
-  });
+		const res = await authedGet("/api/documents");
+		expect(res.status).toBe(200);
+		const items = (res.body as any).items as Array<{
+			id: string;
+			title: string;
+		}>;
+		const ids = items.map((d) => d.id);
+		expect(ids).toContain("11111111-1111-4111-8111-111111111111");
+		expect(ids).toContain("22222222-2222-4222-8222-222222222222");
+		expect(ids).not.toContain("33333333-3333-4333-8333-333333333333");
+	});
 
-  it("respects the page and limit query parameters", async () => {
-    for (let i = 0; i < 5; i++) {
-      seedDocument({
-        id: `${i.toString().padStart(8, "0")}-0000-4000-8000-000000000000`,
-        title: `Doc ${i}`,
-      });
-    }
+	it("respects the page and limit query parameters", async () => {
+		for (let i = 0; i < 5; i++) {
+			seedDocument({
+				id: `${i.toString().padStart(8, "0")}-0000-4000-8000-000000000000`,
+				title: `Doc ${i}`,
+			});
+		}
 
-    const res = await authedGet("/api/documents?page=2&limit=2");
-    expect(res.status).toBe(200);
-    expect((res.body as any).page).toBe(2);
-    expect((res.body as any).limit).toBe(2);
-    expect(((res.body as any).items as any[]).length).toBe(2);
-  });
+		const res = await authedGet("/api/documents?page=2&limit=2");
+		expect(res.status).toBe(200);
+		expect((res.body as any).page).toBe(2);
+		expect((res.body as any).limit).toBe(2);
+		expect(((res.body as any).items as any[]).length).toBe(2);
+	});
 
-  it("rejects limit above 1000", async () => {
-    const res = await authedGet("/api/documents?limit=1001");
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toBe("Invalid query");
-  });
+	it("rejects limit above 1000", async () => {
+		const res = await authedGet("/api/documents?limit=1001");
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toBe("Invalid query");
+	});
 
-  it("rejects a non-uuid folderId filter", async () => {
-    const res = await authedGet("/api/documents?folderId=not-a-uuid");
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toBe("Invalid query");
-  });
+	it("rejects a non-uuid folderId filter", async () => {
+		const res = await authedGet("/api/documents?folderId=not-a-uuid");
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toBe("Invalid query");
+	});
 
-  it("filters by folderId when provided", async () => {
-    const folderId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-    seedDocument({
-      id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-      title: "In folder",
-      folderId,
-    });
-    seedDocument({
-      id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
-      title: "Outside folder",
-      folderId: null,
-    });
+	it("filters by folderId when provided", async () => {
+		const folderId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+		seedDocument({
+			id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+			title: "In folder",
+			folderId,
+		});
+		seedDocument({
+			id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+			title: "Outside folder",
+			folderId: null,
+		});
 
-    const res = await authedGet(`/api/documents?folderId=${folderId}`);
-    expect(res.status).toBe(200);
-    const items = (res.body as any).items as Array<{ id: string }>;
-    const ids = items.map((d) => d.id);
-    expect(ids).toContain("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
-    expect(ids).not.toContain("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
-  });
+		const res = await authedGet(`/api/documents?folderId=${folderId}`);
+		expect(res.status).toBe(200);
+		const items = (res.body as any).items as Array<{ id: string }>;
+		const ids = items.map((d) => d.id);
+		expect(ids).toContain("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+		expect(ids).not.toContain("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+	});
 });
 
 describe("GET /api/documents/cursor", () => {
@@ -287,53 +287,53 @@ describe("GET /api/documents/cursor", () => {
 });
 
 describe("GET /api/documents/:id", () => {
-  it("returns 404 for an unknown id", async () => {
-    const res = await authedGet(
-      "/api/documents/00000000-0000-4000-8000-000000000099",
-    );
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: "Document not found" });
-  });
+	it("returns 404 for an unknown id", async () => {
+		const res = await authedGet(
+			"/api/documents/00000000-0000-4000-8000-000000000099",
+		);
+		expect(res.status).toBe(404);
+		expect(res.body).toEqual({ error: "Document not found" });
+	});
 
-  it("returns 200 with the document and tags for an owned doc", async () => {
-    const doc = seedDocument({
-      id: "44444444-4444-4444-8444-444444444444",
-      title: "My Doc",
-    });
+	it("returns 200 with the document and tags for an owned doc", async () => {
+		const doc = seedDocument({
+			id: "44444444-4444-4444-8444-444444444444",
+			title: "My Doc",
+		});
 
-    const res = await authedGet(`/api/documents/${doc.id}`);
-    expect(res.status).toBe(200);
-    expect((res.body as any).id).toBe(doc.id);
-    expect((res.body as any).title).toBe("My Doc");
-    expect((res.body as any).ownerId).toBe(OWNER_ID);
-    expect(Array.isArray((res.body as any).tags)).toBe(true);
-  });
+		const res = await authedGet(`/api/documents/${doc.id}`);
+		expect(res.status).toBe(200);
+		expect((res.body as any).id).toBe(doc.id);
+		expect((res.body as any).title).toBe("My Doc");
+		expect((res.body as any).ownerId).toBe(OWNER_ID);
+		expect(Array.isArray((res.body as any).tags)).toBe(true);
+	});
 
-  it("returns 404 for a document owned by another user", async () => {
-    seedDocument({
-      id: "55555555-5555-4555-8555-555555555555",
-      title: "Other's Doc",
-      ownerId: OTHER_USER_ID,
-    });
+	it("returns 404 for a document owned by another user", async () => {
+		seedDocument({
+			id: "55555555-5555-4555-8555-555555555555",
+			title: "Other's Doc",
+			ownerId: OTHER_USER_ID,
+		});
 
-    const res = await authedGet(
-      "/api/documents/55555555-5555-4555-8555-555555555555",
-    );
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: "Document not found" });
-  });
+		const res = await authedGet(
+			"/api/documents/55555555-5555-4555-8555-555555555555",
+		);
+		expect(res.status).toBe(404);
+		expect(res.body).toEqual({ error: "Document not found" });
+	});
 
-  it("returns 401 with an invalid bearer token", async () => {
-    const doc = seedDocument({ id: "66666666-6666-4666-8666-666666666666" });
-    const res = await request(app, `/api/documents/${doc.id}`, {
-      method: "GET",
-      headers: {
-        authorization: "Bearer wrong-api-key",
-        "content-type": "application/json",
-      },
-    });
-    expect(res.status).toBe(401);
-  });
+	it("returns 401 with an invalid bearer token", async () => {
+		const doc = seedDocument({ id: "66666666-6666-4666-8666-666666666666" });
+		const res = await request(app, `/api/documents/${doc.id}`, {
+			method: "GET",
+			headers: {
+				authorization: "Bearer wrong-api-key",
+				"content-type": "application/json",
+			},
+		});
+		expect(res.status).toBe(401);
+	});
 });
 
 describe("GET /api/documents/:id/pipeline", () => {
@@ -348,329 +348,368 @@ describe("GET /api/documents/:id/pipeline", () => {
 	it("returns only the owner's latest pipeline progress", async () => {
 		seedDocument({ id: "doc-pipeline", ownerId: OWNER_ID, title: "pipeline" });
 		getState().pipelineRuns.set("run-old", {
-			documentId: "doc-pipeline", ownerId: OWNER_ID, generationId: "gen-old",
-			revision: "rev-old", status: "ready", prepareStatus: "ready", embedStatus: "ready",
-			graphStatus: "skipped", summarizeStatus: "skipped", finalizeStatus: "ready",
-			totalBatches: 1, completedBatches: 1, failedBatches: 0,
+			documentId: "doc-pipeline",
+			ownerId: OWNER_ID,
+			generationId: "gen-old",
+			revision: "rev-old",
+			status: "ready",
+			prepareStatus: "ready",
+			embedStatus: "ready",
+			graphStatus: "skipped",
+			summarizeStatus: "skipped",
+			finalizeStatus: "ready",
+			totalBatches: 1,
+			completedBatches: 1,
+			failedBatches: 0,
 			updatedAt: new Date("2026-01-01"),
 		});
 		getState().pipelineRuns.set("run-new", {
-			documentId: "doc-pipeline", ownerId: OWNER_ID, generationId: "gen-new",
-			revision: "rev-new", status: "processing", prepareStatus: "ready", embedStatus: "processing",
-			graphStatus: "pending", summarizeStatus: "pending", finalizeStatus: "pending",
-			totalBatches: 2, completedBatches: 1, failedBatches: 0,
+			documentId: "doc-pipeline",
+			ownerId: OWNER_ID,
+			generationId: "gen-new",
+			revision: "rev-new",
+			status: "processing",
+			prepareStatus: "ready",
+			embedStatus: "processing",
+			graphStatus: "pending",
+			summarizeStatus: "pending",
+			finalizeStatus: "pending",
+			totalBatches: 2,
+			completedBatches: 1,
+			failedBatches: 0,
 			updatedAt: new Date("2026-01-02"),
 		});
 		getState().pipelineRuns.set("run-other", {
-			documentId: "doc-pipeline", ownerId: OTHER_USER_ID, generationId: "gen-other",
-			revision: "rev-other", status: "ready", updatedAt: new Date("2026-01-03"),
+			documentId: "doc-pipeline",
+			ownerId: OTHER_USER_ID,
+			generationId: "gen-other",
+			revision: "rev-other",
+			status: "ready",
+			updatedAt: new Date("2026-01-03"),
 		});
 		const res = await authedGet("/api/documents/doc-pipeline/pipeline");
 		expect(res.status).toBe(200);
-		expect(res.body).toMatchObject({ generationId: "gen-new", status: "processing", batches: { completed: 1, total: 2 } });
+		expect(res.body).toMatchObject({
+			generationId: "gen-new",
+			status: "processing",
+			batches: { completed: 1, total: 2 },
+		});
+	});
+});
+
+describe("POST /api/documents/:id/pipeline/retry-warnings", () => {
+	it("validates the public document identifier before queue access", async () => {
+		const res = await authedPost(
+			"/api/documents/not-a-uuid/pipeline/retry-warnings",
+			{},
+		);
+		expect(res.status).toBe(400);
+		expect(res.body).toEqual({ error: "Invalid document id" });
 	});
 });
 
 describe("POST /api/documents", () => {
-  it("returns 403 from CSRF middleware on POST without Bearer or CSRF token", async () => {
-    const res = await request(app, "/api/documents", {
-      method: "POST",
-      headers: noAuthHeaders(),
-      body: JSON.stringify({ title: "Test" }),
-    });
-    expect(res.status).toBe(403);
-    expect((res.body as any).error).toMatch(/CSRF/i);
-  });
+	it("returns 403 from CSRF middleware on POST without Bearer or CSRF token", async () => {
+		const res = await request(app, "/api/documents", {
+			method: "POST",
+			headers: noAuthHeaders(),
+			body: JSON.stringify({ title: "Test" }),
+		});
+		expect(res.status).toBe(403);
+		expect((res.body as any).error).toMatch(/CSRF/i);
+	});
 
-  it("returns 400 when title is empty", async () => {
-    const res = await authedPost("/api/documents", { title: "" });
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toBe("Invalid input");
-  });
+	it("returns 400 when title is empty", async () => {
+		const res = await authedPost("/api/documents", { title: "" });
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toBe("Invalid input");
+	});
 
-  it("returns 400 when title exceeds 500 chars", async () => {
-    const res = await authedPost("/api/documents", { title: "a".repeat(501) });
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toBe("Invalid input");
-  });
+	it("returns 400 when title exceeds 500 chars", async () => {
+		const res = await authedPost("/api/documents", { title: "a".repeat(501) });
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toBe("Invalid input");
+	});
 
-  it("returns 400 for an invalid folderId", async () => {
-    const res = await authedPost("/api/documents", {
-      title: "Bad folder",
-      folderId: "not-a-uuid",
-    });
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toBe("Invalid input");
-  });
+	it("returns 400 for an invalid folderId", async () => {
+		const res = await authedPost("/api/documents", {
+			title: "Bad folder",
+			folderId: "not-a-uuid",
+		});
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toBe("Invalid input");
+	});
 
-  it("creates a document and returns 201", async () => {
-    const res = await authedPost("/api/documents", {
-      title: "My first doc",
-      content: "# Hello",
-    });
-    expect(res.status).toBe(201);
-    const body = res.body as { id: string; title: string; ownerId: string };
-    expect(body.title).toBe("My first doc");
-    expect(body.ownerId).toBe(OWNER_ID);
-    expect(body.id).toBeTruthy();
+	it("creates a document and returns 201", async () => {
+		const res = await authedPost("/api/documents", {
+			title: "My first doc",
+			content: "# Hello",
+		});
+		expect(res.status).toBe(201);
+		const body = res.body as { id: string; title: string; ownerId: string };
+		expect(body.title).toBe("My first doc");
+		expect(body.ownerId).toBe(OWNER_ID);
+		expect(body.id).toBeTruthy();
 
-    // Verify the document is in the state
-    const stored = getState().documents.get(body.id);
-    expect(stored).toBeTruthy();
-    expect((stored as any).title).toBe("My first doc");
-    expect((stored as any).ownerId).toBe(OWNER_ID);
+		// Verify the document is in the state
+		const stored = getState().documents.get(body.id);
+		expect(stored).toBeTruthy();
+		expect((stored as any).title).toBe("My first doc");
+		expect((stored as any).ownerId).toBe(OWNER_ID);
 
-    // Embedding should have been enqueued
-    expect(getState().enqueuedEmbeddings).toContain(body.id);
-  });
+		// Embedding should have been enqueued
+		expect(getState().enqueuedEmbeddings).toContain(body.id);
+	});
 
-  it("locks tenant topology before resolving and creating an attached document", async () => {
-    const folderId = "00000000-0000-4000-8000-000000000123";
-    getState().folders.set(folderId, {
-      id: folderId,
-      ownerId: OWNER_ID,
-      parentId: null,
-      categoryId: "00000000-0000-4000-8000-000000000122",
-      name: "Attached folder",
-    });
-    const res = await authedPost("/api/documents", {
-      title: "Attached",
-      folderId,
-    });
-    expect(res.status).toBe(201);
-    const state = getState();
-    const topologyLockIndex = state.calls.findIndex(
-      (call) => call.kind === "lock:topology",
-    );
-    const resolveIndex = state.calls.findIndex(
-      (call) => call.kind === "resolve:folder-category",
-    );
-    const insertIndex = state.calls.findIndex(
-      (call) => call.kind === "insert" && call.table === "documents",
-    );
-    expect(topologyLockIndex).toBeGreaterThanOrEqual(0);
-    expect(resolveIndex).toBeGreaterThan(topologyLockIndex);
-    expect(insertIndex).toBeGreaterThan(topologyLockIndex);
-  });
+	it("locks tenant topology before resolving and creating an attached document", async () => {
+		const folderId = "00000000-0000-4000-8000-000000000123";
+		getState().folders.set(folderId, {
+			id: folderId,
+			ownerId: OWNER_ID,
+			parentId: null,
+			categoryId: "00000000-0000-4000-8000-000000000122",
+			name: "Attached folder",
+		});
+		const res = await authedPost("/api/documents", {
+			title: "Attached",
+			folderId,
+		});
+		expect(res.status).toBe(201);
+		const state = getState();
+		const topologyLockIndex = state.calls.findIndex(
+			(call) => call.kind === "lock:topology",
+		);
+		const resolveIndex = state.calls.findIndex(
+			(call) => call.kind === "resolve:folder-category",
+		);
+		const insertIndex = state.calls.findIndex(
+			(call) => call.kind === "insert" && call.table === "documents",
+		);
+		expect(topologyLockIndex).toBeGreaterThanOrEqual(0);
+		expect(resolveIndex).toBeGreaterThan(topologyLockIndex);
+		expect(insertIndex).toBeGreaterThan(topologyLockIndex);
+	});
 
-  it("defaults the title to 'Untitled' when omitted", async () => {
-    const res = await authedPost("/api/documents", {});
-    expect(res.status).toBe(201);
-    expect((res.body as any).title).toBe("Untitled");
-  });
+	it("defaults the title to 'Untitled' when omitted", async () => {
+		const res = await authedPost("/api/documents", {});
+		expect(res.status).toBe(201);
+		expect((res.body as any).title).toBe("Untitled");
+	});
 
-  it("returns 401 with an invalid bearer token", async () => {
-    const res = await request(app, "/api/documents", {
-      method: "POST",
-      headers: {
-        authorization: "Bearer wrong-api-key",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ title: "Nope" }),
-    });
-    expect(res.status).toBe(401);
-  });
+	it("returns 401 with an invalid bearer token", async () => {
+		const res = await request(app, "/api/documents", {
+			method: "POST",
+			headers: {
+				authorization: "Bearer wrong-api-key",
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ title: "Nope" }),
+		});
+		expect(res.status).toBe(401);
+	});
 });
 
 describe("POST /api/documents/:id/duplicate", () => {
-  it("locks tenant topology before reading and duplicating attached source placement", async () => {
-    const source = seedDocument({
-      id: "00000000-0000-4000-8000-000000000124",
-      folderId: "00000000-0000-4000-8000-000000000125",
-    });
+	it("locks tenant topology before reading and duplicating attached source placement", async () => {
+		const source = seedDocument({
+			id: "00000000-0000-4000-8000-000000000124",
+			folderId: "00000000-0000-4000-8000-000000000125",
+		});
 
-    const res = await authedPost(`/api/documents/${source.id}/duplicate`, {});
+		const res = await authedPost(`/api/documents/${source.id}/duplicate`, {});
 
-    expect(res.status).toBe(201);
-    const state = getState();
-    const topologyLockIndex = state.calls.findIndex(
-      (call) => call.kind === "lock:topology",
-    );
-    const sourceReadIndex = state.calls.findIndex(
-      (call) => call.kind === "select" && call.table === "documents",
-    );
-    const insertIndex = state.calls.findIndex(
-      (call) => call.kind === "insert" && call.table === "documents",
-    );
-    expect(topologyLockIndex).toBeGreaterThanOrEqual(0);
-    expect(sourceReadIndex).toBeGreaterThan(topologyLockIndex);
-    expect(insertIndex).toBeGreaterThan(topologyLockIndex);
-  });
+		expect(res.status).toBe(201);
+		const state = getState();
+		const topologyLockIndex = state.calls.findIndex(
+			(call) => call.kind === "lock:topology",
+		);
+		const sourceReadIndex = state.calls.findIndex(
+			(call) => call.kind === "select" && call.table === "documents",
+		);
+		const insertIndex = state.calls.findIndex(
+			(call) => call.kind === "insert" && call.table === "documents",
+		);
+		expect(topologyLockIndex).toBeGreaterThanOrEqual(0);
+		expect(sourceReadIndex).toBeGreaterThan(topologyLockIndex);
+		expect(insertIndex).toBeGreaterThan(topologyLockIndex);
+	});
 });
 
 describe("PATCH /api/documents/:id", () => {
-  it("returns 404 for an unknown document", async () => {
-    const res = await authedPatch(
-      "/api/documents/00000000-0000-4000-8000-000000000099",
-      { title: "Renamed" },
-    );
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: "Document not found" });
-  });
+	it("returns 404 for an unknown document", async () => {
+		const res = await authedPatch(
+			"/api/documents/00000000-0000-4000-8000-000000000099",
+			{ title: "Renamed" },
+		);
+		expect(res.status).toBe(404);
+		expect(res.body).toEqual({ error: "Document not found" });
+	});
 
-  it("returns 400 when no fields are provided", async () => {
-    const doc = seedDocument({ id: "77777777-7777-4777-8777-777777777777" });
-    const res = await authedPatch(`/api/documents/${doc.id}`, {});
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toMatch(/at least one field/i);
-  });
+	it("returns 400 when no fields are provided", async () => {
+		const doc = seedDocument({ id: "77777777-7777-4777-8777-777777777777" });
+		const res = await authedPatch(`/api/documents/${doc.id}`, {});
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toMatch(/at least one field/i);
+	});
 
-  it("returns 400 for an invalid title", async () => {
-    const doc = seedDocument({ id: "88888888-8888-4888-8888-888888888888" });
-    const res = await authedPatch(`/api/documents/${doc.id}`, { title: "" });
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toBe("Invalid input");
-  });
+	it("returns 400 for an invalid title", async () => {
+		const doc = seedDocument({ id: "88888888-8888-4888-8888-888888888888" });
+		const res = await authedPatch(`/api/documents/${doc.id}`, { title: "" });
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toBe("Invalid input");
+	});
 
-  it("renames a document", async () => {
-    const doc = seedDocument({
-      id: "99999999-9999-4999-8999-999999999999",
-      title: "Old",
-    });
+	it("renames a document", async () => {
+		const doc = seedDocument({
+			id: "99999999-9999-4999-8999-999999999999",
+			title: "Old",
+		});
 
-    const res = await authedPatch(`/api/documents/${doc.id}`, {
-      title: "New",
-    });
-    expect(res.status).toBe(200);
-    expect((res.body as any).title).toBe("New");
+		const res = await authedPatch(`/api/documents/${doc.id}`, {
+			title: "New",
+		});
+		expect(res.status).toBe(200);
+		expect((res.body as any).title).toBe("New");
 
-    const stored = getState().documents.get(doc.id) as any;
-    expect(stored.title).toBe("New");
-  });
+		const stored = getState().documents.get(doc.id) as any;
+		expect(stored.title).toBe("New");
+	});
 
-  it("updates when expectedUpdatedAt matches the server timestamp", async () => {
-    const doc = seedDocument({
-      id: "99999999-9999-4999-8999-999999999998",
-      title: "Old",
-      updatedAt: new Date("2024-06-01T00:00:00.000Z"),
-    });
+	it("updates when expectedUpdatedAt matches the server timestamp", async () => {
+		const doc = seedDocument({
+			id: "99999999-9999-4999-8999-999999999998",
+			title: "Old",
+			updatedAt: new Date("2024-06-01T00:00:00.000Z"),
+		});
 
-    const res = await authedPatch(`/api/documents/${doc.id}`, {
-      title: "New",
-      expectedUpdatedAt: doc.updatedAt.toISOString(),
-    });
-    expect(res.status).toBe(200);
-    expect((res.body as any).title).toBe("New");
-  });
+		const res = await authedPatch(`/api/documents/${doc.id}`, {
+			title: "New",
+			expectedUpdatedAt: doc.updatedAt.toISOString(),
+		});
+		expect(res.status).toBe(200);
+		expect((res.body as any).title).toBe("New");
+	});
 
-  it("returns a structured 409 conflict without version or update side effects", async () => {
-    const doc = seedDocument({
-      id: "99999999-9999-4999-8999-999999999997",
-      title: "Server title",
-      content: "Server body",
-      contentJson: { type: "doc" },
-      updatedAt: new Date("2024-06-01T00:00:00.000Z"),
-    });
+	it("returns a structured 409 conflict without version or update side effects", async () => {
+		const doc = seedDocument({
+			id: "99999999-9999-4999-8999-999999999997",
+			title: "Server title",
+			content: "Server body",
+			contentJson: { type: "doc" },
+			updatedAt: new Date("2024-06-01T00:00:00.000Z"),
+		});
 
-    const res = await authedPatch(`/api/documents/${doc.id}`, {
-      title: "Local title",
-      expectedUpdatedAt: "2024-05-31T00:00:00.000Z",
-    });
-    expect(res.status).toBe(409);
-    expect(res.body).toEqual({
-      error: "Document changed on the server",
-      code: "DOCUMENT_CONFLICT",
-      currentUpdatedAt: doc.updatedAt.toISOString(),
-      serverVersion: {
-        id: doc.id,
-        title: "Server title",
-        content: "Server body",
-        contentJson: { type: "doc" },
-      },
-    });
-    expect(getState().documents.get(doc.id)).toMatchObject({ title: "Server title" });
-    expect(getState().versions).toHaveLength(0);
-    expect(getState().enqueuedEmbeddings).not.toContain(doc.id);
-  });
+		const res = await authedPatch(`/api/documents/${doc.id}`, {
+			title: "Local title",
+			expectedUpdatedAt: "2024-05-31T00:00:00.000Z",
+		});
+		expect(res.status).toBe(409);
+		expect(res.body).toEqual({
+			error: "Document changed on the server",
+			code: "DOCUMENT_CONFLICT",
+			currentUpdatedAt: doc.updatedAt.toISOString(),
+			serverVersion: {
+				id: doc.id,
+				title: "Server title",
+				content: "Server body",
+				contentJson: { type: "doc" },
+			},
+		});
+		expect(getState().documents.get(doc.id)).toMatchObject({
+			title: "Server title",
+		});
+		expect(getState().versions).toHaveLength(0);
+		expect(getState().enqueuedEmbeddings).not.toContain(doc.id);
+	});
 
-  it("rejects an expectedUpdatedAt value without an explicit timezone", async () => {
-    const doc = seedDocument({ id: "99999999-9999-4999-8999-999999999996" });
-    const res = await authedPatch(`/api/documents/${doc.id}`, {
-      title: "New",
-      expectedUpdatedAt: "2024-06-01T00:00:00",
-    });
-    expect(res.status).toBe(400);
-    expect((res.body as any).error).toBe("Invalid input");
-  });
+	it("rejects an expectedUpdatedAt value without an explicit timezone", async () => {
+		const doc = seedDocument({ id: "99999999-9999-4999-8999-999999999996" });
+		const res = await authedPatch(`/api/documents/${doc.id}`, {
+			title: "New",
+			expectedUpdatedAt: "2024-06-01T00:00:00",
+		});
+		expect(res.status).toBe(400);
+		expect((res.body as any).error).toBe("Invalid input");
+	});
 
-  it("updates content and re-enqueues embedding", async () => {
-    const doc = seedDocument({
-      id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
-      title: "Keep",
-      content: "old body",
-    });
+	it("updates content and re-enqueues embedding", async () => {
+		const doc = seedDocument({
+			id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+			title: "Keep",
+			content: "old body",
+		});
 
-    const res = await authedPatch(`/api/documents/${doc.id}`, {
-      content: "new body",
-    });
-    expect(res.status).toBe(200);
+		const res = await authedPatch(`/api/documents/${doc.id}`, {
+			content: "new body",
+		});
+		expect(res.status).toBe(200);
 
-    const stored = getState().documents.get(doc.id) as any;
-    expect(stored.content).toBe("new body");
+		const stored = getState().documents.get(doc.id) as any;
+		expect(stored.content).toBe("new body");
 
-    // Embedding should have been re-enqueued
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(getState().enqueuedEmbeddings).toContain(doc.id);
-    expect(
-      getState().calls.some((call) => call.kind === "lock:topology"),
-    ).toBe(false);
-  });
+		// Embedding should have been re-enqueued
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(getState().enqueuedEmbeddings).toContain(doc.id);
+		expect(getState().calls.some((call) => call.kind === "lock:topology")).toBe(
+			false,
+		);
+	});
 
-  it("moves a document to a different folder", async () => {
-    const doc = seedDocument({
-      id: "abcdef00-0000-4000-8000-000000000000",
-      folderId: null,
-    });
-    const newFolder = "abcdef01-0000-4000-8000-000000000000";
+	it("moves a document to a different folder", async () => {
+		const doc = seedDocument({
+			id: "abcdef00-0000-4000-8000-000000000000",
+			folderId: null,
+		});
+		const newFolder = "abcdef01-0000-4000-8000-000000000000";
 
-    const res = await authedPatch(`/api/documents/${doc.id}`, {
-      folderId: newFolder,
-    });
-    expect(res.status).toBe(200);
-    expect((res.body as any).folderId).toBe(newFolder);
-    const state = getState();
-    const topologyLockIndex = state.calls.findIndex(
-      (call) => call.kind === "lock:topology",
-    );
-    const updateIndex = state.calls.findIndex(
-      (call) => call.kind === "update" && call.table === "documents",
-    );
-    expect(topologyLockIndex).toBeGreaterThanOrEqual(0);
-    expect(updateIndex).toBeGreaterThan(topologyLockIndex);
-  });
+		const res = await authedPatch(`/api/documents/${doc.id}`, {
+			folderId: newFolder,
+		});
+		expect(res.status).toBe(200);
+		expect((res.body as any).folderId).toBe(newFolder);
+		const state = getState();
+		const topologyLockIndex = state.calls.findIndex(
+			(call) => call.kind === "lock:topology",
+		);
+		const updateIndex = state.calls.findIndex(
+			(call) => call.kind === "update" && call.table === "documents",
+		);
+		expect(topologyLockIndex).toBeGreaterThanOrEqual(0);
+		expect(updateIndex).toBeGreaterThan(topologyLockIndex);
+	});
 
-  it("stores the current content revision atomically with a placement and content update", async () => {
-    const document = seedDocument({
-      id: "abcdef08-0000-4000-8000-000000000000",
-      folderId: null,
-      title: "Old title",
-      content: "Old body",
-      contentHash: "old-revision",
-    });
-    const folderId = "abcdef09-0000-4000-8000-000000000000";
-    getState().folders.set(folderId, {
-      id: folderId,
-      ownerId: OWNER_ID,
-      name: "Revision destination",
-      parentId: null,
-      categoryId: null,
-    });
+	it("stores the current content revision atomically with a placement and content update", async () => {
+		const document = seedDocument({
+			id: "abcdef08-0000-4000-8000-000000000000",
+			folderId: null,
+			title: "Old title",
+			content: "Old body",
+			contentHash: "old-revision",
+		});
+		const folderId = "abcdef09-0000-4000-8000-000000000000";
+		getState().folders.set(folderId, {
+			id: folderId,
+			ownerId: OWNER_ID,
+			name: "Revision destination",
+			parentId: null,
+			categoryId: null,
+		});
 
-    const response = await authedPatch(`/api/documents/${document.id}`, {
-      folderId,
-      title: "New title",
-      content: "New body",
-    });
+		const response = await authedPatch(`/api/documents/${document.id}`, {
+			folderId,
+			title: "New title",
+			content: "New body",
+		});
 
-    expect(response.status).toBe(200);
-    expect(getState().documents.get(document.id)).toMatchObject({
-      folderId,
-      title: "New title",
-      content: "New body",
-      contentHash:
-        "7fe2b3933fae78c3d1ec53d0f9cb3f7c7325ed99da90b6d53a78d3533d66a22e",
-    });
-  });
+		expect(response.status).toBe(200);
+		expect(getState().documents.get(document.id)).toMatchObject({
+			folderId,
+			title: "New title",
+			content: "New body",
+			contentHash:
+				"7fe2b3933fae78c3d1ec53d0f9cb3f7c7325ed99da90b6d53a78d3533d66a22e",
+		});
+	});
 
 	it("rolls back a placement change when its outbox snapshot cannot commit", async () => {
 		const document = seedDocument({
@@ -698,113 +737,113 @@ describe("PATCH /api/documents/:id", () => {
 		expect(getState().calls.at(-1)?.kind).toBe("transaction:rollback");
 	});
 
-  it("invalidates the cached list before acknowledging a placement update", async () => {
-    const doc = seedDocument({
-      id: "abcdef03-0000-4000-8000-000000000000",
-      folderId: null,
-      categoryId: null,
-    });
-    const newFolder = "abcdef04-0000-4000-8000-000000000000";
-    const newCategory = "abcdef05-0000-4000-8000-000000000000";
+	it("invalidates the cached list before acknowledging a placement update", async () => {
+		const doc = seedDocument({
+			id: "abcdef03-0000-4000-8000-000000000000",
+			folderId: null,
+			categoryId: null,
+		});
+		const newFolder = "abcdef04-0000-4000-8000-000000000000";
+		const newCategory = "abcdef05-0000-4000-8000-000000000000";
 
-    const before = await authedGet("/api/documents?limit=100");
-    expect(before.status).toBe(200);
-    expect(
-      (before.body as any).items.find((item: any) => item.id === doc.id)
-        .folderId,
-    ).toBeNull();
+		const before = await authedGet("/api/documents?limit=100");
+		expect(before.status).toBe(200);
+		expect(
+			(before.body as any).items.find((item: any) => item.id === doc.id)
+				.folderId,
+		).toBeNull();
 
-    const moved = await authedPatch(`/api/documents/${doc.id}`, {
-      folderId: newFolder,
-      categoryId: newCategory,
-    });
-    expect(moved.status).toBe(200);
+		const moved = await authedPatch(`/api/documents/${doc.id}`, {
+			folderId: newFolder,
+			categoryId: newCategory,
+		});
+		expect(moved.status).toBe(200);
 
-    const after = await authedGet("/api/documents?limit=100");
-    const listed = (after.body as any).items.find(
-      (item: any) => item.id === doc.id,
-    );
-    expect(listed.folderId).toBe(newFolder);
-    expect(listed.categoryId).toBe(newCategory);
-  });
+		const after = await authedGet("/api/documents?limit=100");
+		const listed = (after.body as any).items.find(
+			(item: any) => item.id === doc.id,
+		);
+		expect(listed.folderId).toBe(newFolder);
+		expect(listed.categoryId).toBe(newCategory);
+	});
 
-  it("returns 404 when updating a document owned by another user", async () => {
-    seedDocument({
-      id: "abcdef02-0000-4000-8000-000000000000",
-      ownerId: OTHER_USER_ID,
-    });
-    const res = await authedPatch(
-      "/api/documents/abcdef02-0000-4000-8000-000000000000",
-      { title: "X" },
-    );
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: "Document not found" });
-  });
+	it("returns 404 when updating a document owned by another user", async () => {
+		seedDocument({
+			id: "abcdef02-0000-4000-8000-000000000000",
+			ownerId: OTHER_USER_ID,
+		});
+		const res = await authedPatch(
+			"/api/documents/abcdef02-0000-4000-8000-000000000000",
+			{ title: "X" },
+		);
+		expect(res.status).toBe(404);
+		expect(res.body).toEqual({ error: "Document not found" });
+	});
 });
 
 describe("DELETE /api/documents/:id", () => {
-  it("returns 404 for an unknown document", async () => {
-    const res = await authedDelete(
-      "/api/documents/00000000-0000-4000-8000-000000000099",
-    );
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: "Document not found" });
-  });
+	it("returns 404 for an unknown document", async () => {
+		const res = await authedDelete(
+			"/api/documents/00000000-0000-4000-8000-000000000099",
+		);
+		expect(res.status).toBe(404);
+		expect(res.body).toEqual({ error: "Document not found" });
+	});
 
-  it("deletes an owned document", async () => {
-    const doc = seedDocument({ id: "deadbeef-0000-4000-8000-000000000000" });
-    const res = await authedDelete(`/api/documents/${doc.id}`);
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ success: true });
+	it("deletes an owned document", async () => {
+		const doc = seedDocument({ id: "deadbeef-0000-4000-8000-000000000000" });
+		const res = await authedDelete(`/api/documents/${doc.id}`);
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual({ success: true });
 		expect(getState().documents.get(doc.id)?.deletedAt).toBeInstanceOf(Date);
-  });
+	});
 
-  it("does not delete a document owned by another user", async () => {
-    const doc = seedDocument({
-      id: "deadbee1-0000-4000-8000-000000000000",
-      ownerId: OTHER_USER_ID,
-    });
-    const res = await authedDelete(`/api/documents/${doc.id}`);
-    expect(res.status).toBe(404);
-    expect(getState().documents.has(doc.id)).toBe(true);
-  });
+	it("does not delete a document owned by another user", async () => {
+		const doc = seedDocument({
+			id: "deadbee1-0000-4000-8000-000000000000",
+			ownerId: OTHER_USER_ID,
+		});
+		const res = await authedDelete(`/api/documents/${doc.id}`);
+		expect(res.status).toBe(404);
+		expect(getState().documents.has(doc.id)).toBe(true);
+	});
 
-  it("returns 401 with an invalid bearer token", async () => {
-    const doc = seedDocument({ id: "deadbee2-0000-4000-8000-000000000000" });
-    const res = await request(app, `/api/documents/${doc.id}`, {
-      method: "DELETE",
-      headers: {
-        authorization: "Bearer wrong-api-key",
-        "content-type": "application/json",
-      },
-    });
-    expect(res.status).toBe(401);
-  });
+	it("returns 401 with an invalid bearer token", async () => {
+		const doc = seedDocument({ id: "deadbee2-0000-4000-8000-000000000000" });
+		const res = await request(app, `/api/documents/${doc.id}`, {
+			method: "DELETE",
+			headers: {
+				authorization: "Bearer wrong-api-key",
+				"content-type": "application/json",
+			},
+		});
+		expect(res.status).toBe(401);
+	});
 });
 
 describe("Document API auth integration", () => {
-  it("uses OWNER_ID when the test API key is presented", async () => {
-    const create = await authedPost("/api/documents", {
-      title: "API key flow",
-    });
-    expect(create.status).toBe(201);
-    expect((create.body as any).ownerId).toBe(OWNER_ID);
+	it("uses OWNER_ID when the test API key is presented", async () => {
+		const create = await authedPost("/api/documents", {
+			title: "API key flow",
+		});
+		expect(create.status).toBe(201);
+		expect((create.body as any).ownerId).toBe(OWNER_ID);
 
-    const list = await authedGet("/api/documents");
-    expect(list.status).toBe(200);
-    const items = (list.body as any).items as Array<{ id: string }>;
-    const found = items.find((d) => d.id === (create.body as any).id);
-    expect(found).toBeTruthy();
-  });
+		const list = await authedGet("/api/documents");
+		expect(list.status).toBe(200);
+		const items = (list.body as any).items as Array<{ id: string }>;
+		const found = items.find((d) => d.id === (create.body as any).id);
+		expect(found).toBeTruthy();
+	});
 
-  it("rejects a wrong Bearer token with 401", async () => {
-    const res = await request(app, "/api/documents", {
-      method: "GET",
-      headers: {
-        authorization: "Bearer wrong-api-key",
-        "content-type": "application/json",
-      },
-    });
-    expect(res.status).toBe(401);
-  });
+	it("rejects a wrong Bearer token with 401", async () => {
+		const res = await request(app, "/api/documents", {
+			method: "GET",
+			headers: {
+				authorization: "Bearer wrong-api-key",
+				"content-type": "application/json",
+			},
+		});
+		expect(res.status).toBe(401);
+	});
 });

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     },
     "backend": {
       "name": "@hiai-docs/backend",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1121.0",
         "@aws-sdk/s3-request-presigner": "^3.1121.0",
@@ -66,7 +66,7 @@
     },
     "frontend": {
       "name": "@hiai-docs/frontend",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@hiai-gg/hiai-ui": "^0.1.3",
@@ -137,7 +137,7 @@
     },
     "packages/cli": {
       "name": "@hiai-docs/cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "bin": {
         "hiai-docs": "./src/index.ts",
       },
@@ -151,7 +151,7 @@
     },
     "packages/db": {
       "name": "@hiai-docs/db",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9",
@@ -165,7 +165,7 @@
     },
     "packages/mcp-server": {
       "name": "@hiai-docs/mcp-server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "bin": {
         "hiai-docs-mcp": "./src/index.ts",
       },
@@ -182,7 +182,7 @@
     },
     "packages/sdk": {
       "name": "@hiai-docs/sdk",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "devDependencies": {
         "@types/bun": "^1.4.0",
         "@types/node": "^26.0.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,7 +270,7 @@ services:
       network: host
       args:
         PUBLIC_APP_ID: ${PUBLIC_APP_ID:-docsmint}
-        PUBLIC_DEPLOYMENT_ID: ${PUBLIC_DEPLOYMENT_ID:-docsmint-oss-0.8.1}
+        PUBLIC_DEPLOYMENT_ID: ${PUBLIC_DEPLOYMENT_ID:-docsmint-oss-0.8.2}
     restart: unless-stopped
     ports:
       # WEB_PORT selects only the published host port. The container contract

--- a/docs/API.md
+++ b/docs/API.md
@@ -170,9 +170,13 @@ Knowledge-pipeline clients can read the active generation's summary with
 `GET /api/documents/:id/knowledge-summary`, inspect embedding and pipeline
 readiness with `GET /api/documents/:id/index-status`, and request an idempotent
 reindex with `POST /api/documents/:id/index/refresh`. The read endpoints require
-document read access; refresh requires write access. For category-scoped
+document read access; refresh requires write access. A
+`ready_with_warnings` pipeline includes a machine-readable `warnings` array.
+Call `POST /api/documents/:id/pipeline/retry-warnings` to retry only retryable
+graph or summarization warnings on the current active embedding generation;
+ready embeddings, chunks, and optional stages are preserved. For category-scoped
 assertions, each operation checks the document's direct category or its
-effective category inherited from folder ancestry before access. All three
+effective category inherited from folder ancestry before access. All four
 validate UUID parameters and are rate limited.
 
 ### Search

--- a/docs/http-route-inventory.json
+++ b/docs/http-route-inventory.json
@@ -67,6 +67,7 @@
   "POST /api/documents/{id}/attachments/presign",
   "POST /api/documents/{id}/duplicate",
   "POST /api/documents/{id}/index/refresh",
+  "POST /api/documents/{id}/pipeline/retry-warnings",
   "POST /api/documents/{id}/publish",
   "POST /api/documents/{id}/tags",
   "POST /api/documents/{id}/unpublish",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1702,14 +1702,15 @@
       },
       "DocsPipelineWarningRetry": {
         "type": "object",
-        "required": ["documentId", "generationId", "retriedStages"],
+        "required": ["documentId", "generationId", "retriedStages", "deduplicated"],
         "properties": {
           "documentId": { "type": "string", "format": "uuid" },
           "generationId": { "type": "string", "format": "uuid" },
           "retriedStages": {
             "type": "array",
             "items": { "type": "string", "enum": ["graph", "summarize"] }
-          }
+          },
+          "deduplicated": { "type": "boolean" }
         }
       },
       "DocsDocumentIndexStatus": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "DocsMint API",
     "description": "Self-hosted AI-native knowledge workspace and installable PWA with hybrid search, GraphRAG, REST, SDK, CLI, and MCP access for people and AI agents.",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "contact": {
       "name": "HiAi-gg",
       "url": "https://github.com/HiAi-gg/docsmint"
@@ -717,6 +717,35 @@
             "BearerAuth": []
           }
         ]
+      }
+    },
+    "/api/documents/{id}/pipeline/retry-warnings": {
+      "post": {
+        "operationId": "retryDocumentPipelineWarnings",
+        "summary": "Retry failed optional pipeline stages",
+        "description": "Retries only retryable graph and summarization warning stages on the active embedding generation. Ready embeddings, chunks, and optional stages are preserved.",
+        "parameters": [
+          {
+            "schema": { "type": "string", "format": "uuid" },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Warning-stage retry accepted.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DocsPipelineWarningRetry" }
+              }
+            }
+          },
+          "401": { "description": "Authentication is required." },
+          "403": { "description": "The caller lacks write permission." },
+          "409": { "description": "No retryable warning stages exist." }
+        },
+        "security": [{ "SessionAuth": [] }, { "BearerAuth": [] }]
       }
     },
     "/api/documents/{id}/knowledge-summary": {
@@ -1628,7 +1657,7 @@
       "DocsDocumentPipeline": {
         "type": "object",
         "nullable": true,
-        "required": ["documentId", "generationId", "status", "revision", "stages", "batches", "updatedAt"],
+        "required": ["documentId", "generationId", "status", "revision", "stages", "batches", "warnings", "updatedAt"],
         "properties": {
           "documentId": { "type": "string", "format": "uuid" },
           "generationId": { "type": "string", "format": "uuid" },
@@ -1654,7 +1683,31 @@
               "failed": { "type": "integer" }
             }
           },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["stage", "code", "retryable"],
+              "properties": {
+                "stage": { "type": "string", "enum": ["graph", "summarize"] },
+                "code": { "type": "string" },
+                "retryable": { "type": "boolean" }
+              }
+            }
+          },
           "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "DocsPipelineWarningRetry": {
+        "type": "object",
+        "required": ["documentId", "generationId", "retriedStages"],
+        "properties": {
+          "documentId": { "type": "string", "format": "uuid" },
+          "generationId": { "type": "string", "format": "uuid" },
+          "retriedStages": {
+            "type": "array",
+            "items": { "type": "string", "enum": ["graph", "summarize"] }
+          }
         }
       },
       "DocsDocumentIndexStatus": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -741,9 +741,11 @@
               }
             }
           },
+          "400": { "description": "Invalid document identifier." },
           "401": { "description": "Authentication is required." },
           "403": { "description": "The caller lacks write permission." },
-          "409": { "description": "No retryable warning stages exist." }
+          "409": { "description": "No retryable warning stages exist." },
+          "429": { "description": "Too many requests." }
         },
         "security": [{ "SessionAuth": [] }, { "BearerAuth": [] }]
       }

--- a/docs/superpowers/plans/2026-08-31-oss-0.8.2-hardening.md
+++ b/docs/superpowers/plans/2026-08-31-oss-0.8.2-hardening.md
@@ -1,0 +1,295 @@
+# DocsMint OSS 0.8.2 Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct reranker identity mapping, restore the supported frontend package boundary, and add retryable, machine-readable optional pipeline warnings without rebuilding embeddings.
+
+**Architecture:** Keep rerank identity in one filtered record array, consume hiai-ui only through its public root export, and extend the durable pipeline run with stage-specific warning codes plus a transactionally claimed retry operation. All API changes are additive and preserve tenant access, RLS, search responses, active generations, and existing refresh behavior.
+
+**Tech Stack:** Bun 1.4, TypeScript 6, Elysia, Drizzle/PostgreSQL, BullMQ, SvelteKit/Svelte 5, Zod, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-oss-0.8.2-hardening-design.md`
+
+## Global Constraints
+
+- Work only in `/mnt/data/projects/docsmint-oss`; do not modify DocsMint SaaS.
+- Do not change tenant/workspace authorization, RLS, or the search response schema.
+- Do not disable reranking or GraphRAG.
+- Preserve existing SDK/API fields; new pipeline fields and methods must be additive.
+- Use public package exports only; no source aliases or copied hiai-ui implementation.
+- Release from `main` only and remove the temporary worktree and feature branch afterward.
+
+---
+
+### Task 1: Reranker candidate identity
+
+**Files:**
+- Modify: `backend/src/search/rerank-provider.ts`
+- Test: `backend/src/__tests__/rerank-provider.test.ts`
+- Test: `backend/src/__tests__/rerank.test.ts`
+
+**Interfaces:**
+- Consumes: `RerankRequest.candidates` and provider result indexes.
+- Produces: unchanged `RerankProviderResult | null` with IDs resolved from filtered candidate records.
+
+- [ ] **Step 1: Write failing provider mapping tests**
+
+Add table-driven tests where empty candidates occur first, in the middle, and multiple times. Capture the request body and assert provider documents omit empty text while returned indexes map to the IDs and scores from those same filtered records.
+
+- [ ] **Step 2: Write failing fallback tests**
+
+Cover all-empty input without fetch, partial provider results, duplicate indexes/IDs, negative/non-integer/out-of-range indexes, provider error/timeout, and stable missing-hit order through `applyRerankOrder`.
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+bun test backend/src/__tests__/rerank-provider.test.ts backend/src/__tests__/rerank.test.ts
+```
+
+Expected: identity tests fail because provider indexes currently address the unfiltered ID array.
+
+- [ ] **Step 4: Implement one filtered record array**
+
+Create records before filtering:
+
+```ts
+const candidates = input.candidates
+  .map((candidate, originalIndex) => ({
+    id: candidate.id,
+    document: candidate.text.trim(),
+    originalIndex,
+  }))
+  .filter((candidate) => candidate.document.length > 0);
+```
+
+Pass `candidates.map(({ document }) => document)` to the provider and resolve each provider index through `candidates[index]?.id`. Reject non-integer indexes and collapse duplicate IDs.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+Run the two focused suites and commit:
+
+```bash
+git add backend/src/search/rerank-provider.ts backend/src/__tests__/rerank-provider.test.ts backend/src/__tests__/rerank.test.ts
+git commit -m "fix(search): preserve reranker candidate identity"
+```
+
+### Task 2: Frontend public package import
+
+**Files:**
+- Modify: `frontend/src/lib/stores/theme.svelte.ts`
+- Modify: `frontend/src/lib/hiai-ui-import-contract.test.ts`
+- Modify: `scripts/verify-packed-package.ts` if the packed consumer lacks a frontend import assertion.
+
+**Interfaces:**
+- Consumes: `runThemeSpread` and `ThemeSpreadOrigin` from `@hiai-gg/hiai-ui`.
+- Produces: unchanged `themeStore` and theme transition behavior.
+
+- [ ] **Step 1: Strengthen the package-boundary test**
+
+Assert that the installed package root export contains `runThemeSpread`, that the frontend source imports it from `@hiai-gg/hiai-ui`, and that no frontend source imports `@hiai-gg/hiai-ui/lib/theme-spread` or resolves through a source alias.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+bun test frontend/src/lib/hiai-ui-import-contract.test.ts
+```
+
+Expected: fail on the unsupported subpath import.
+
+- [ ] **Step 3: Switch to the official root export**
+
+Replace only the module specifier in `theme.svelte.ts`; preserve wrapper logic, `tick`, theme storage, favicon behavior, and transition origin types.
+
+- [ ] **Step 4: Verify standalone and packed imports**
+
+Run frontend unit tests, frontend build, and the package verifier. Confirm the packed consumer has no source aliases and can resolve the installed hiai-ui root.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/stores/theme.svelte.ts frontend/src/lib/hiai-ui-import-contract.test.ts scripts/verify-packed-package.ts
+git commit -m "fix(frontend): use the public hiai-ui theme export"
+```
+
+### Task 3: Typed provider failure diagnostics
+
+**Files:**
+- Modify: `backend/src/lib/openai-compatible-chat.ts`
+- Modify: `backend/src/lib/knowledge-summary-provider.ts`
+- Modify: `backend/src/lib/graph/extract-entities.ts`
+- Test: `backend/src/__tests__/openai-compatible-chat.test.ts`
+- Test: `backend/src/__tests__/knowledge-summary.test.ts`
+- Test: `backend/src/__tests__/graph-extract.test.ts`
+
+**Interfaces:**
+- Produces: internal `StructuredChatFailureCode` classification and an exhausted-provider result carrying the final diagnostic code.
+- Preserves: ordered provider fallback and existing successful result shape.
+
+- [ ] **Step 1: Add failing classification tests**
+
+Cover timeout/AbortError, HTTP status failure, malformed JSON, empty content, Zod-invalid output, and no configured provider. Assert provider fallback still succeeds when a later slot is valid.
+
+- [ ] **Step 2: Verify RED**
+
+Run the focused structured-chat, graph extraction, and summary suites.
+
+- [ ] **Step 3: Implement typed classification**
+
+Introduce internal errors/results with codes `provider_timeout`, `provider_http_error`, `provider_invalid_json`, `provider_invalid_response`, and `provider_unavailable`. Preserve model-safe structured logging and never include credentials or response bodies.
+
+- [ ] **Step 4: Propagate final codes to graph and summary outcomes**
+
+Replace generic `provider_failed`/`Error` name loss with the final typed code while retaining fallback behavior.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run the focused suites before proceeding to persistence.
+
+### Task 4: Durable stage warnings
+
+**Files:**
+- Create: `packages/db/src/migrations/0048_pipeline_stage_error_codes.sql`
+- Modify: `packages/db/src/schema.ts`
+- Modify: `packages/db/src/pipeline-schema.test.ts`
+- Modify: `backend/src/queue/adapters.ts`
+- Modify: `backend/src/api/routes/documents.ts`
+- Modify: `packages/sdk/src/types.ts`
+- Modify: `docs/openapi.json`
+- Test: relevant route and SDK contract suites.
+
+**Interfaces:**
+- Produces: `graphErrorCode`, `summarizeErrorCode`, and additive `warnings` arrays.
+- Preserves: legacy `errorCode`, statuses, routes, and existing response fields.
+
+- [ ] **Step 1: Add failing schema and response contract tests**
+
+Assert both new nullable columns exist, simultaneous graph and summary failures yield two warnings, successful/retrying stages clear only their own code, and old `errorCode` remains.
+
+- [ ] **Step 2: Verify RED**
+
+Run DB schema, pipeline route, SDK type/client, and OpenAPI contract tests.
+
+- [ ] **Step 3: Add migration and Drizzle columns**
+
+Use idempotent nullable column additions. Do not alter enum values, indexes, foreign keys, or RLS.
+
+- [ ] **Step 4: Persist and expose stage codes**
+
+Make `setStageStatus` update the stage-specific error column. Add a pure warning serializer mapping failed optional stages to `{ stage, code, retryable }`; include it in both pipeline endpoints.
+
+- [ ] **Step 5: Update SDK/OpenAPI additively and verify GREEN**
+
+Add `DocsPipelineWarning` and optional/additive `warnings` without removing or renaming any existing field.
+
+### Task 5: Retry failed warning stages only
+
+**Files:**
+- Create: `backend/src/queue/retry-warning-stages.ts`
+- Modify: `backend/src/queue/adapters.ts`
+- Modify: `backend/src/queue/stage-policies.ts`
+- Modify: `backend/src/api/routes/documents.ts`
+- Modify: `packages/sdk/src/client.ts`
+- Modify: `packages/sdk/src/types.ts`
+- Modify: `docs/API.md`
+- Modify: `docs/openapi.json`
+- Test: new retry planner tests, route contracts, queue worker tests, SDK client tests, PostgreSQL integration tests.
+
+**Interfaces:**
+- Produces: `POST /api/documents/:id/pipeline/retry-warnings` and `DocsClient.retryDocumentPipelineWarnings`.
+- Response: `{ documentId, generationId, stages, deduplicated }`.
+
+- [ ] **Step 1: Write failing retry planner tests**
+
+Cover graph-only, summary-only, both failed, no failures, already retrying, stale revision/generation, authorization reuse, and concurrent duplicate claims. Assert generation/chunks/embeddings are never created or changed.
+
+- [ ] **Step 2: Write failing idempotency tests**
+
+Assert graph-only retry does not regenerate a ready summary, summary upsert remains one row, graph MERGE remains generation-scoped, and duplicate API requests enqueue one logical chain.
+
+- [ ] **Step 3: Verify RED**
+
+Run focused planner, worker, route, SDK, and PostgreSQL integration tests.
+
+- [ ] **Step 4: Implement transactionally claimed retry plan**
+
+Lock the latest current run under the existing tenant context. Reset only failed optional stages, clear their error codes, mark the run processing, and enqueue graph first when needed or summary otherwise. Return `deduplicated: true` for no-op/already-active requests.
+
+- [ ] **Step 5: Preserve ready summary on graph-only retry**
+
+Teach summary stage policy to detect an already-ready status and advance directly to finalize without calling the provider.
+
+- [ ] **Step 6: Add route, SDK, MCP exposure, and docs**
+
+Reuse the exact document lookup and `write` authorization predicates from index refresh. Add the operation to public SDK exports and, if appropriate for the document-manager catalog, a backward-compatible MCP tool without changing existing tools.
+
+- [ ] **Step 7: Verify GREEN and commit pipeline work**
+
+Run all focused suites and commit migration, backend, SDK, OpenAPI, MCP, and docs together:
+
+```bash
+git commit -m "feat(pipeline): retry failed warning stages safely"
+```
+
+### Task 6: Complete verification
+
+**Files:** no intended production changes unless a verified regression requires a focused fix.
+
+- [ ] **Step 1: Frozen install and format check**
+
+Run `bun install --frozen-lockfile`, `bunx biome check .`, and `git diff --check`.
+
+- [ ] **Step 2: Lint and typecheck**
+
+Run `bun run lint` and `bun run typecheck`.
+
+- [ ] **Step 3: Full unit suites**
+
+Run root unit tests, all backend unit tests, and all frontend tests; capture passed, failed, and skipped counts.
+
+- [ ] **Step 4: Integration suites**
+
+Run search/rerank/pipeline integrations and required PostgreSQL integrations using the repository's configured test database. Report unavailable infrastructure separately and do not label the release ready if required tests cannot run.
+
+- [ ] **Step 5: Build and packed consumer**
+
+Build every publishable workspace, run `bun run test:package`, pack the public package, install it into a temporary clean Bun consumer, and import every public export plus the frontend surface.
+
+- [ ] **Step 6: Inspect intended diff**
+
+Confirm the worktree contains only intended files and no generated secrets, `.env` changes, aliases, or SaaS paths.
+
+### Task 7: Review, PR, and 0.8.2 release
+
+**Files:** release manifests, `CHANGELOG.md`, workflow version constants, lockfile workspace versions, and catalog manifests required by the existing release validator.
+
+- [ ] **Step 1: Request code review and address findings**
+
+Review all commits and run fresh focused verification after any change.
+
+- [ ] **Step 2: Prepare a separate 0.8.2 release commit**
+
+Update every version surface using the existing 0.8.1 release pattern. Add concise release notes for all three fixes and run release validators.
+
+- [ ] **Step 3: Push feature branch and open PR**
+
+Include root causes, compatibility statement, changed-file groups, exact test counts, and release plan. Wait for required checks and merge to `main` without bypassing failures.
+
+- [ ] **Step 4: Tag exact main commit**
+
+Verify `main` equals the merged PR commit, create annotated `v0.8.2`, push the tag, and monitor the complete tag release gate through npm, containers, MCP Registry, and GitHub Release.
+
+- [ ] **Step 5: Verify published artifacts**
+
+Check npm version/provenance, download the published tarball into a clean Bun consumer, verify public exports and the frontend package import, and record the exact release SHA.
+
+- [ ] **Step 6: Clean temporary development state**
+
+Remove the worktree and local/remote feature branch after merge and release. Confirm only `main` remains for this task.
+
+- [ ] **Step 7: Provide SaaS adoption instructions without changing SaaS**
+
+Document the exact package version and release SHA to use for both the SaaS dependency and submodule pin. Do not apply those changes in the closed repository.

--- a/docs/superpowers/specs/2026-08-31-oss-0.8.2-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-31-oss-0.8.2-hardening-design.md
@@ -1,0 +1,135 @@
+# DocsMint OSS 0.8.2 Hardening Design
+
+## Scope
+
+Fix three defects in the standalone DocsMint OSS repository: reranker candidate
+identity drift, an unsupported frontend package subpath import, and incomplete
+recovery and diagnostics for optional GraphRAG pipeline stages. No DocsMint SaaS
+code, tenant authorization rule, RLS policy, or search response schema changes.
+
+The work starts from `main` after OSS 0.8.1 (`a9d709f`) plus the two README-only
+commits already present on `main`. It ships as three logical fixes followed by a
+0.8.2 release commit.
+
+## Reranker Candidate Identity
+
+`requestRerank` will construct one ordered array of `{ id, document,
+originalIndex }` records before filtering. It will trim and filter those records
+as a unit, send only their `document` values to the provider, and resolve every
+provider index through the same filtered record array.
+
+Provider rows with non-integer, negative, or out-of-range indexes are ignored.
+Duplicate indexes or document IDs contribute at most one hit. Partial responses
+remain partial; `applyRerankOrder` appends every missing candidate in stable RRF
+order. Empty input, all-empty input, provider failure, timeout, or disabled
+reranking preserve existing fail-open behavior and the public search response.
+
+Regression tests will cover empty candidates at the beginning and middle,
+multiple and all-empty candidates, partial results, unknown indexes, duplicates,
+correct ID/score association, and stable fallback order.
+
+## Frontend Package Boundary
+
+`@hiai-gg/hiai-ui@0.1.3` already exports `runThemeSpread` and
+`ThemeSpreadOrigin` from its root entrypoint. The frontend will import them from
+`@hiai-gg/hiai-ui`, not from `@hiai-gg/hiai-ui/lib/theme-spread`. No dependency
+bump, source alias, copied implementation, or visual behavior change is needed.
+
+A package-boundary test will inspect the installed package export map and import
+the root package under the same installed dependency graph used by standalone
+frontend tests. A packed-consumer check will verify that the published DocsMint
+frontend surface contains no source alias or unsupported hiai-ui subpath.
+
+## Pipeline Failure Classification
+
+The structured-chat provider layer will return or throw typed diagnostic
+categories while preserving the current fallback chain:
+
+- `provider_timeout` for aborted provider calls;
+- `provider_http_error` for non-success HTTP responses;
+- `provider_invalid_json` for malformed JSON;
+- `provider_invalid_response` for schema-invalid or empty responses;
+- `provider_unavailable` when no provider is configured.
+
+Each provider slot still falls through independently. Only the final exhausted
+classification is persisted; logs retain the provider/model context without
+credentials. Permanent validation failures are diagnostic failures rather than
+retryable transport failures.
+
+## Durable Warning Diagnostics
+
+Migration `0048_pipeline_stage_error_codes.sql` adds nullable
+`graph_error_code` and `summarize_error_code` columns. The existing
+`error_code` remains for backward compatibility and for whole-run failures.
+Stage status writers clear their own code when a retry begins or succeeds and
+write their own code on failure.
+
+Pipeline and index-status responses gain an additive `warnings` array:
+
+```ts
+type DocsPipelineWarning = {
+  stage: "graph" | "summarize";
+  code: string;
+  retryable: boolean;
+};
+```
+
+Existing fields and status values remain unchanged. A
+`ready_with_warnings` response contains one entry for every failed optional
+stage, so simultaneous graph and summary failures remain machine-readable.
+
+## Retry Only Warning Stages
+
+Add `POST /api/documents/:id/pipeline/retry-warnings` and SDK method
+`retryDocumentPipelineWarnings(id, context?)`. Authorization exactly matches
+the existing index refresh endpoint: read identifies the document, and explicit
+write permission is required to retry. Category and effective-folder scoping use
+the existing content-access predicates.
+
+Within a tenant transaction, the retry planner locks the latest pipeline run and
+validates that it belongs to the document's active embedding generation and
+current revision. It never creates a generation, chunks, or embeddings. It
+selects only failed graph and summary stages:
+
+- graph failed: reset graph to `retrying`; keep a ready summary intact;
+- summary failed: reset summary to `retrying`;
+- both failed: reset both, enqueue graph first, then continue to summary;
+- no failed warning stage or an already retrying stage: return an idempotent
+  no-op result.
+
+The response is additive and explicit:
+
+```ts
+type DocsPipelineWarningRetry = {
+  documentId: string;
+  generationId: string;
+  stages: Array<"graph" | "summarize">;
+  deduplicated: boolean;
+};
+```
+
+Queue jobs use the existing generation identity, revision fence, workspace
+scope, attempts, and exponential backoff. A completed summary is not regenerated
+when only graph failed. Graph AGE writes remain idempotent because document and
+entity nodes and generation-scoped relations use `MERGE`; summary persistence
+continues to upsert on document and generation.
+
+## Contracts and Tests
+
+The OpenAPI document, SDK types/client, MCP index-status representation, and
+documentation will receive only additive fields and the new operation. Existing
+`refreshDocumentIndex` remains unchanged and continues to request a complete
+index refresh.
+
+Verification must include frozen install, Biome format/check and lint, full
+typecheck, all backend unit tests, all frontend tests, targeted rerank and
+pipeline tests, required integration tests, every publishable workspace build,
+and a clean packed consumer that resolves public exports without aliases.
+
+## Delivery
+
+Create separate commits for reranker identity, frontend package import,
+pipeline retry/diagnostics, and 0.8.2 release metadata. Open a PR to `main`, run
+the complete release gate, merge to `main`, and create the `v0.8.2` tag and
+GitHub Release from the exact merged commit. Remove the temporary worktree and
+feature branch after release so only `main` remains locally.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-docs/frontend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/frontend/src/lib/components/CreateSnapshotDialog.svelte
+++ b/frontend/src/lib/components/CreateSnapshotDialog.svelte
@@ -14,7 +14,7 @@ import {
 	DialogTitle,
 } from "@hiai-gg/hiai-ui/components/ui/dialog/index";
 import { Input } from "@hiai-gg/hiai-ui/components/ui/input/index";
-import { Textarea } from "@hiai-gg/hiai-ui/components/ui/textarea/index";
+import Textarea from "@hiai-gg/hiai-ui/components/ui/textarea/textarea.svelte";
 import { Loader2 } from "lucide-svelte";
 import { ApiError, apiFetch } from "$lib/api/client";
 import { getDocsmintRequestAdapter } from "$lib/hosts/route-context";

--- a/frontend/src/lib/components/DocumentCard.svelte
+++ b/frontend/src/lib/components/DocumentCard.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-import { Badge } from "@hiai-gg/hiai-ui/components/ui/badge/index";
-import {
-	Card,
-	CardContent,
-	CardHeader,
-} from "@hiai-gg/hiai-ui/components/ui/card/index";
+import Badge from "@hiai-gg/hiai-ui/components/ui/badge/badge.svelte";
+import Card from "@hiai-gg/hiai-ui/components/ui/card/card.svelte";
+import CardContent from "@hiai-gg/hiai-ui/components/ui/card/card-content.svelte";
+import CardHeader from "@hiai-gg/hiai-ui/components/ui/card/card-header.svelte";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/frontend/src/lib/components/FolderCard.svelte
+++ b/frontend/src/lib/components/FolderCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { Card, CardContent } from "@hiai-gg/hiai-ui/components/ui/card/index";
+import Card from "@hiai-gg/hiai-ui/components/ui/card/card.svelte";
+import CardContent from "@hiai-gg/hiai-ui/components/ui/card/card-content.svelte";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/frontend/src/lib/components/FolderDialog.svelte
+++ b/frontend/src/lib/components/FolderDialog.svelte
@@ -10,7 +10,7 @@ import {
 	DialogTitle,
 } from "@hiai-gg/hiai-ui/components/ui/dialog/index";
 import { Input } from "@hiai-gg/hiai-ui/components/ui/input/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import { CheckCircle2, Loader2 } from "lucide-svelte";
 import * as m from "$lib/paraglide/messages.js";
 

--- a/frontend/src/lib/components/MoveDialog.svelte
+++ b/frontend/src/lib/components/MoveDialog.svelte
@@ -8,7 +8,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@hiai-gg/hiai-ui/components/ui/dialog/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import { Loader2 } from "lucide-svelte";
 import { type Category, listCategories } from "$lib/api/categories";
 import { listFolders } from "$lib/api/folders";

--- a/frontend/src/lib/components/PwaInstallPrompt.svelte
+++ b/frontend/src/lib/components/PwaInstallPrompt.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { Button } from "@hiai-gg/hiai-ui/components/ui/button/index";
-import { Card, CardContent } from "@hiai-gg/hiai-ui/components/ui/card/index";
+import Card from "@hiai-gg/hiai-ui/components/ui/card/card.svelte";
+import CardContent from "@hiai-gg/hiai-ui/components/ui/card/card-content.svelte";
 import { Download, X } from "lucide-svelte";
 import { onMount } from "svelte";
 

--- a/frontend/src/lib/components/SaveAsDialog.svelte
+++ b/frontend/src/lib/components/SaveAsDialog.svelte
@@ -8,7 +8,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@hiai-gg/hiai-ui/components/ui/dialog/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import SelectRoot from "@hiai-gg/hiai-ui/components/ui/select/select.svelte";
 import SelectContent from "@hiai-gg/hiai-ui/components/ui/select/select-content.svelte";
 import SelectItem from "@hiai-gg/hiai-ui/components/ui/select/select-item.svelte";

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -2,7 +2,7 @@
 import { Button } from "@hiai-gg/hiai-ui/components/ui/button/index";
 import * as Dialog from "@hiai-gg/hiai-ui/components/ui/dialog/index";
 import { Input } from "@hiai-gg/hiai-ui/components/ui/input/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import * as Tabs from "@hiai-gg/hiai-ui/components/ui/tabs/index";
 import { Loader2, LogOut, Save } from "lucide-svelte";
 import { onMount } from "svelte";

--- a/frontend/src/lib/components/TagCreateDialog.svelte
+++ b/frontend/src/lib/components/TagCreateDialog.svelte
@@ -10,7 +10,7 @@ import {
 	DialogTitle,
 } from "@hiai-gg/hiai-ui/components/ui/dialog/index";
 import { Input } from "@hiai-gg/hiai-ui/components/ui/input/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import { Loader2 } from "lucide-svelte";
 import {
 	createTag,

--- a/frontend/src/lib/components/sidebar/CategoryDialog.svelte
+++ b/frontend/src/lib/components/sidebar/CategoryDialog.svelte
@@ -24,7 +24,7 @@ import {
 	DialogTitle,
 } from "@hiai-gg/hiai-ui/components/ui/dialog/index";
 import { Input } from "@hiai-gg/hiai-ui/components/ui/input/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import SelectRoot from "@hiai-gg/hiai-ui/components/ui/select/select.svelte";
 import SelectContent from "@hiai-gg/hiai-ui/components/ui/select/select-content.svelte";
 import SelectItem from "@hiai-gg/hiai-ui/components/ui/select/select-item.svelte";

--- a/frontend/src/lib/components/sidebar/FolderTree.svelte
+++ b/frontend/src/lib/components/sidebar/FolderTree.svelte
@@ -32,7 +32,7 @@ import {
 	DropdownMenuTrigger,
 } from "@hiai-gg/hiai-ui/components/ui/dropdown-menu/index";
 import { Input } from "@hiai-gg/hiai-ui/components/ui/input/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import {
 	Check,
 	ChevronDown,

--- a/frontend/src/lib/components/sidebar/RecentDocs.svelte
+++ b/frontend/src/lib/components/sidebar/RecentDocs.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { Button } from "@hiai-gg/hiai-ui/components/ui/button/index";
 import { ConfirmDialog } from "@hiai-gg/hiai-ui";
+import { Button } from "@hiai-gg/hiai-ui/components/ui/button/index";
 import {
 	Dialog,
 	DialogContent,

--- a/frontend/src/lib/components/sidebar/RecentDocs.svelte
+++ b/frontend/src/lib/components/sidebar/RecentDocs.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { Button } from "@hiai-gg/hiai-ui/components/ui/button/index";
-import { ConfirmDialog } from "@hiai-gg/hiai-ui/components/ui/confirm-dialog/index";
+import { ConfirmDialog } from "@hiai-gg/hiai-ui";
 import {
 	Dialog,
 	DialogContent,
@@ -16,7 +16,7 @@ import {
 	DropdownMenuTrigger,
 } from "@hiai-gg/hiai-ui/components/ui/dropdown-menu/index";
 import { Input } from "@hiai-gg/hiai-ui/components/ui/input/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import { Check, Copy, FileText, Loader2, MoreVertical } from "lucide-svelte";
 import { onDestroy, onMount } from "svelte";
 import {

--- a/frontend/src/lib/components/sidebar/TagList.svelte
+++ b/frontend/src/lib/components/sidebar/TagList.svelte
@@ -1,6 +1,6 @@
 <!-- TagList.svelte — Sidebar list of tags with filter toggle, create, edit, delete. -->
 <script lang="ts">
-import { ConfirmDialog } from "@hiai-gg/hiai-ui/components/ui/confirm-dialog/index";
+import { ConfirmDialog } from "@hiai-gg/hiai-ui";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/frontend/src/lib/hiai-ui-import-contract.test.ts
+++ b/frontend/src/lib/hiai-ui-import-contract.test.ts
@@ -13,7 +13,9 @@ describe("hiai-ui package import contract", () => {
 
 		const entry = import.meta.resolve("@hiai-gg/hiai-ui");
 		const packageRoot = resolve(dirname(new URL(entry).pathname), "..");
-		const manifest = await Bun.file(resolve(packageRoot, "package.json")).json();
+		const manifest = await Bun.file(
+			resolve(packageRoot, "package.json"),
+		).json();
 		const rootExport = manifest.exports?.["."] as
 			| Record<string, string>
 			| undefined;

--- a/frontend/src/lib/hiai-ui-import-contract.test.ts
+++ b/frontend/src/lib/hiai-ui-import-contract.test.ts
@@ -4,6 +4,38 @@ import { dirname, resolve } from "node:path";
 const HIAI_UI_IMPORT = /["'](@hiai-gg\/hiai-ui\/[^"']+)["']/g;
 
 describe("hiai-ui package import contract", () => {
+	test("theme spread uses the installed package root export", async () => {
+		const themeStore = await Bun.file(
+			resolve(import.meta.dir, "stores/theme.svelte.ts"),
+		).text();
+		expect(themeStore).toContain('from "@hiai-gg/hiai-ui"');
+		expect(themeStore).not.toContain("@hiai-gg/hiai-ui/lib/theme-spread");
+
+		const entry = import.meta.resolve("@hiai-gg/hiai-ui");
+		const packageRoot = resolve(dirname(new URL(entry).pathname), "..");
+		const manifest = await Bun.file(resolve(packageRoot, "package.json")).json();
+		const rootExport = manifest.exports?.["."] as
+			| Record<string, string>
+			| undefined;
+		expect(rootExport?.types).toBe("./dist/index.d.ts");
+		expect(rootExport?.svelte).toBe("./dist/index.js");
+
+		const declarations = await Bun.file(
+			resolve(packageRoot, rootExport?.types ?? ""),
+		).text();
+		const runtime = await Bun.file(
+			resolve(packageRoot, rootExport?.svelte ?? ""),
+		).text();
+		expect(declarations).toContain("runThemeSpread");
+		expect(runtime).toContain("runThemeSpread");
+
+		const svelteConfig = await Bun.file(
+			resolve(import.meta.dir, "../../svelte.config.js"),
+		).text();
+		expect(svelteConfig).not.toContain("hiaiUiDist");
+		expect(svelteConfig).not.toContain('"@hiai-gg/hiai-ui"');
+	});
+
 	test("every frontend import resolves to an exported package target", async () => {
 		const entry = import.meta.resolve("@hiai-gg/hiai-ui");
 		const packageRoot = resolve(dirname(new URL(entry).pathname), "..");

--- a/frontend/src/lib/hosts/HiaiDocsDashboardHost.svelte
+++ b/frontend/src/lib/hosts/HiaiDocsDashboardHost.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Badge } from "@hiai-gg/hiai-ui/components/ui/badge/index";
+import Badge from "@hiai-gg/hiai-ui/components/ui/badge/badge.svelte";
 import { Button } from "@hiai-gg/hiai-ui/components/ui/button/index";
 import {
 	DropdownMenu,
@@ -7,7 +7,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@hiai-gg/hiai-ui/components/ui/dropdown-menu/index";
-import { Label } from "@hiai-gg/hiai-ui/components/ui/label/index";
+import Label from "@hiai-gg/hiai-ui/components/ui/label/label.svelte";
 import SelectRoot from "@hiai-gg/hiai-ui/components/ui/select/select.svelte";
 import SelectContent from "@hiai-gg/hiai-ui/components/ui/select/select-content.svelte";
 import SelectItem from "@hiai-gg/hiai-ui/components/ui/select/select-item.svelte";
@@ -48,7 +48,7 @@ const Select = {
 	Value: SelectValue,
 };
 
-import { ConfirmDialog } from "@hiai-gg/hiai-ui/components/ui/confirm-dialog/index";
+import { ConfirmDialog } from "@hiai-gg/hiai-ui";
 import { invalidateAll } from "$app/navigation";
 import { page } from "$app/state";
 import type { Category } from "$lib/api/categories";

--- a/frontend/src/lib/hosts/HiaiDocsSearchHost.svelte
+++ b/frontend/src/lib/hosts/HiaiDocsSearchHost.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Badge } from "@hiai-gg/hiai-ui/components/ui/badge/index";
+import Badge from "@hiai-gg/hiai-ui/components/ui/badge/badge.svelte";
 import SelectRoot from "@hiai-gg/hiai-ui/components/ui/select/select.svelte";
 import SelectContent from "@hiai-gg/hiai-ui/components/ui/select/select-content.svelte";
 import SelectItem from "@hiai-gg/hiai-ui/components/ui/select/select-item.svelte";

--- a/frontend/src/lib/offline/__tests__/service-worker-policy.test.ts
+++ b/frontend/src/lib/offline/__tests__/service-worker-policy.test.ts
@@ -30,7 +30,7 @@ describe("service worker offline fallback policy", () => {
 		expect(config).toContain('src: "/pwa-192x192.png"');
 		expect(config).toContain('src: "/pwa-512x512.png"');
 		expect(config).toContain('src: "/maskable-icon.png"');
-		expect(config).toContain('"docsmint-oss-0.8.1"');
+		expect(config).toContain('"docsmint-oss-0.8.2"');
 		expect(hooks).toContain('register("/sw.js", { scope: "/" })');
 		expect(hooks).toContain('postMessage({ type: "SKIP_WAITING" })');
 		expect(worker).toContain("void self.skipWaiting()");
@@ -48,7 +48,7 @@ describe("service worker offline fallback policy", () => {
 			expect(existsSync(new URL(icon, frontendRoot)), icon).toBe(true);
 		}
 		expect(compose).toContain("PUBLIC_DEPLOYMENT_ID:");
-		expect(compose).toContain("PUBLIC_DEPLOYMENT_ID:-docsmint-oss-0.8.1");
+		expect(compose).toContain("PUBLIC_DEPLOYMENT_ID:-docsmint-oss-0.8.2");
 	});
 
 	it("ships a data-free offline HTML shell", async () => {

--- a/frontend/src/lib/stores/theme.svelte.ts
+++ b/frontend/src/lib/stores/theme.svelte.ts
@@ -1,7 +1,7 @@
 import {
 	runThemeSpread as spreadFromClick,
 	type ThemeSpreadOrigin,
-} from "@hiai-gg/hiai-ui/lib/theme-spread";
+} from "@hiai-gg/hiai-ui";
 import { tick } from "svelte";
 import { browser } from "$app/environment";
 

--- a/frontend/src/routes/(app)/docs/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/docs/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <!-- Document editor page -->
 <script lang="ts">
-import { ConfirmDialog } from "@hiai-gg/hiai-ui/components/ui/confirm-dialog/index";
+import { ConfirmDialog } from "@hiai-gg/hiai-ui";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,10 +1,5 @@
 import adapter from "@sveltejs/adapter-node";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
-import { fileURLToPath } from "node:url";
-
-const hiaiUiDist = fileURLToPath(
-  new URL("./node_modules/@hiai-gg/hiai-ui/dist", import.meta.url),
-);
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -23,14 +18,6 @@ const config = {
     // hooks.client.ts owns the only registration at `/sw.js`.
     serviceWorker: {
       register: false,
-    },
-    // hiai-ui@0.0.8 exposes component directories through a wildcard export,
-    // but TypeScript cannot resolve directory indexes from that map. Keep the
-    // compatibility alias in SvelteKit (the canonical alias surface) rather
-    // than overriding generated paths in tsconfig.json.
-    alias: {
-      "@hiai-gg/hiai-ui": `${hiaiUiDist}/index.js`,
-      "@hiai-gg/hiai-ui/*": `${hiaiUiDist}/*`,
     },
   },
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
 	const env = loadEnv(mode, process.cwd(), "");
 	const appId = env.PUBLIC_APP_ID ?? env.VITE_APP_ID ?? "hiai-docs";
 	const deploymentId =
-		env.PUBLIC_DEPLOYMENT_ID ?? env.VITE_DEPLOYMENT_ID ?? "docsmint-oss-0.8.1";
+		env.PUBLIC_DEPLOYMENT_ID ?? env.VITE_DEPLOYMENT_ID ?? "docsmint-oss-0.8.2";
 
 	return {
   plugins: [

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "hiai-gg-docsmint",
   "name": "DocsMint",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "HiAi-gg",
   "authorUrl": "https://github.com/HiAi-gg",
   "category": "developer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-docs/workspace",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "mcpName": "io.github.HiAi-gg/docsmint",
   "private": true,
   "type": "module",

--- a/package.public.json
+++ b/package.public.json
@@ -1,7 +1,7 @@
 {
   "name": "@hiai-gg/docsmint",
   "mcpName": "io.github.HiAi-gg/docsmint",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "browser": {
     "./dist/backend-launcher.js": false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-docs/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,7 +25,7 @@ import { registerSearch } from './commands/search.js';
 import { registerSnapshot } from './commands/snapshot.js';
 import { registerUpdate } from './commands/update.js';
 
-const VERSION = '0.8.1';
+const VERSION = '0.8.2';
 
 const program = new Command();
 program.name('docsmint').description('CLI for the DocsMint knowledge workspace').version(VERSION);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-docs/db",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/db/src/ci-release-gates.test.ts
+++ b/packages/db/src/ci-release-gates.test.ts
@@ -91,7 +91,7 @@ test("tagged web publication receives the validated canonical PWA identity", asy
 	const validator = await Bun.file(
 		new URL("../../../scripts/release-version-validator.ts", import.meta.url),
 	).text();
-	const canonicalDeploymentId = "docsmint-oss-0.8.1";
+	const canonicalDeploymentId = "docsmint-oss-0.8.2";
 
 	expect(vite).toContain(canonicalDeploymentId);
 	expect(compose).toContain(`PUBLIC_DEPLOYMENT_ID:-${canonicalDeploymentId}`);

--- a/packages/db/src/migrations/0048_pipeline_stage_error_codes.sql
+++ b/packages/db/src/migrations/0048_pipeline_stage_error_codes.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.document_pipeline_runs
+  ADD COLUMN IF NOT EXISTS graph_error_code text,
+  ADD COLUMN IF NOT EXISTS summarize_error_code text;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -358,6 +358,13 @@
 			"when": 1788076800000,
 			"tag": "0047_better_auth_17_account_identity",
 			"breakpoints": true
+		},
+		{
+			"idx": 51,
+			"version": "7",
+			"when": 1788163200000,
+			"tag": "0048_pipeline_stage_error_codes",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/pipeline-schema.test.ts
+++ b/packages/db/src/pipeline-schema.test.ts
@@ -26,6 +26,10 @@ const rlsMigration = readFileSync(
 	new URL("./migrations/0031_pipeline_tenant_rls.sql", import.meta.url),
 	"utf8",
 );
+const stageErrorMigration = readFileSync(
+	new URL("./migrations/0048_pipeline_stage_error_codes.sql", import.meta.url),
+	"utf8",
+);
 const journal = JSON.parse(
 	readFileSync(
 		new URL("./migrations/meta/_journal.json", import.meta.url),
@@ -72,6 +76,8 @@ describe("BullMQ pipeline state schema", () => {
 				"completedBatches",
 				"failedBatches",
 				"errorCode",
+				"graphErrorCode",
+				"summarizeErrorCode",
 				"attempts",
 				"heartbeatAt",
 				"updatedAt",
@@ -93,6 +99,11 @@ describe("BullMQ pipeline state schema", () => {
 		);
 		expect(Object.keys(documentPipelineRuns)).not.toContain("content");
 		expect(Object.keys(documentPipelineBatches)).not.toContain("modelOutput");
+	});
+
+	it("stores optional-stage diagnostics independently", () => {
+		expect(stageErrorMigration).toContain("graph_error_code");
+		expect(stageErrorMigration).toContain("summarize_error_code");
 	});
 
 	it("contains idempotency, scheduling, and document cascade constraints", () => {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -296,6 +296,8 @@ export const documentPipelineRuns = pgTable(
     completedBatches: integer("completed_batches").notNull().default(0),
     failedBatches: integer("failed_batches").notNull().default(0),
     errorCode: text("error_code"),
+    graphErrorCode: text("graph_error_code"),
+    summarizeErrorCode: text("summarize_error_code"),
     attempts: integer("attempts").notNull().default(0),
     requestedAt: timestamp("requested_at").defaultNow().notNull(),
     startedAt: timestamp("started_at"),

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-docs/mcp-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -106,7 +106,7 @@ export interface CreateDocsmintMcpServerOptions {
 }
 
 export function createDocsmintMcpServer(options: CreateDocsmintMcpServerOptions = {}): McpServer {
-  const server = new McpServer({ name: 'docsmint', version: '0.8.1' });
+  const server = new McpServer({ name: 'docsmint', version: '0.8.2' });
   const client = options.docsClient
     ? createMcpDocsClient(options.docsClient, options.requestContext)
     : options.client ?? createMcpDocsClient(createDefaultDocsClient(), options.requestContext);

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -64,6 +64,7 @@ new DocsClient({
 - `exportDoc(id)` → alias of `getDocMarkdown`
 - `importDoc({ title, content, folderId })` → `DocsDocument`
 - `getDocumentPipeline(id)` → durable BullMQ stage/batch status
+- `retryDocumentPipelineWarnings(id)` → retry only failed optional stages on the active generation
 - `publishDoc(id)` / `unpublishDoc(id)`
 
 ### Folders

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-docs/sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -472,6 +472,19 @@ describe("DocsClient public contract", () => {
 		);
 	});
 
+	it("retries only warning pipeline stages through the public route", async () => {
+		const calls: Array<{ url: string; method: string }> = [];
+		const docs = client(async (input, init) => {
+			calls.push({ url: String(input), method: init?.method ?? "GET" });
+			return jsonResponse({});
+		});
+		await docs.retryDocumentPipelineWarnings("doc/one");
+		expect(calls.at(-1)?.method).toBe("POST");
+		expect(calls.at(-1)?.url).toEndWith(
+			"/api/documents/doc%2Fone/pipeline/retry-warnings",
+		);
+	});
+
 	it("exposes knowledge summary, index status, and user refresh contracts", async () => {
 		const calls: Array<{ url: string; method: string }> = [];
 		const docs = client(async (input, init) => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -27,6 +27,7 @@ import type {
 	DocsDocumentKnowledgeSummary,
 	DocsDocumentListResponse,
 	DocsDocumentPipeline,
+	DocsPipelineWarningRetry,
 	DocsDocumentUpdateInput,
 	DocsFolder,
 	DocsFolderCreateInput,
@@ -338,6 +339,18 @@ export class DocsClient {
 		return this.request<DocsDocumentPipeline>(
 			"GET",
 			`/api/documents/${encodeURIComponent(id)}/pipeline`,
+			undefined,
+			context,
+		);
+	}
+
+	async retryDocumentPipelineWarnings(
+		id: string,
+		context?: DocsRequestContext,
+	): Promise<DocsPipelineWarningRetry> {
+		return this.request<DocsPipelineWarningRetry>(
+			"POST",
+			`/api/documents/${encodeURIComponent(id)}/pipeline/retry-warnings`,
 			undefined,
 			context,
 		);

--- a/packages/sdk/src/release-consistency.test.ts
+++ b/packages/sdk/src/release-consistency.test.ts
@@ -2,13 +2,13 @@ import { expect, test } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 
 const repositoryRoot = new URL('../../../', import.meta.url);
-const releaseVersion = '0.8.1';
+const releaseVersion = '0.8.2';
 
 async function json(path: string): Promise<Record<string, unknown>> {
   return JSON.parse(await readFile(new URL(path, repositoryRoot), 'utf8'));
 }
 
-test('all published and workspace release metadata reports 0.8.1', async () => {
+test('all published and workspace release metadata reports 0.8.2', async () => {
   for (const path of [
     'package.json',
     'package.public.json',
@@ -111,14 +111,14 @@ test('all published and workspace release metadata reports 0.8.1', async () => {
   }
 
   expect(await readFile(new URL('frontend/vite.config.ts', repositoryRoot), 'utf8')).toContain(
-    'docsmint-oss-0.8.1'
+    'docsmint-oss-0.8.2'
   );
   expect(await readFile(new URL('docker-compose.yml', repositoryRoot), 'utf8')).toContain(
-    'docsmint-oss-0.8.1'
+    'docsmint-oss-0.8.2'
   );
 });
 
-test('workspace and public package metadata share the 0.8.1 product identity', async () => {
+test('workspace and public package metadata share the 0.8.2 product identity', async () => {
   const workspaceManifest = await json('package.json');
   const publicManifest = await json('package.public.json');
   const description =

--- a/packages/sdk/src/release-version-validator.test.ts
+++ b/packages/sdk/src/release-version-validator.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'bun:test';
 import { validateReleaseVersion } from '../../../scripts/release-version-validator.ts';
 
 test('release version validator accepts the synchronized release tag', async () => {
-  await expect(validateReleaseVersion({ root: new URL('../../../', import.meta.url), tag: 'v0.8.1' }))
+  await expect(validateReleaseVersion({ root: new URL('../../../', import.meta.url), tag: 'v0.8.2' }))
     .resolves.toBeUndefined();
 });
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -462,6 +462,7 @@ export interface DocsPipelineWarningRetry {
 	documentId: string;
 	generationId: string;
 	retriedStages: Array<"graph" | "summarize">;
+	deduplicated: boolean;
 }
 
 export interface DocsDocumentKnowledgeSummary {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -448,7 +448,20 @@ export interface DocsDocumentPipeline {
 		finalize: DocsPipelineStatus;
 	};
 	batches: { total: number; completed: number; failed: number };
+	warnings: DocsPipelineWarning[];
 	updatedAt: string;
+}
+
+export interface DocsPipelineWarning {
+	stage: "graph" | "summarize";
+	code: string;
+	retryable: boolean;
+}
+
+export interface DocsPipelineWarningRetry {
+	documentId: string;
+	generationId: string;
+	retriedStages: Array<"graph" | "summarize">;
 }
 
 export interface DocsDocumentKnowledgeSummary {

--- a/server.json
+++ b/server.json
@@ -10,7 +10,7 @@
     "id": "1249550690",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/HiAi-gg/docsmint/main/frontend/static/logo-dark.png",
@@ -30,7 +30,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@hiai-gg/docsmint",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- preserve document identity when empty rerank candidates are filtered
- consume only public hiai-ui exports and verify the packed frontend surface
- add machine-readable pipeline warnings and safe retry of failed optional stages
- prepare the synchronized 0.8.2 patch release and concise marketing README

## Root causes
- reranker indexes were relative to filtered text while IDs remained unfiltered
- the frontend imported a package subpath absent from hiai-ui 0.1.3 exports
- optional graph and summary stages lacked durable error codes and an idempotent failed-stage retry contract

## Compatibility
- search response schema and hybrid ranking semantics are unchanged
- SDK/API additions are additive
- tenant/workspace authorization and RLS remain unchanged

## Verification
- frozen install: pass
- lint: pass
- typecheck / svelte-check: pass (0 errors, 0 warnings)
- unit suites: pass
- contract suites: pass
- frontend: 306 passed, 0 failed
- focused search/rerank/pipeline: 99 passed, 0 failed
- all publishable builds: pass
- packed package consumer: pass; hiai-gg-docsmint-0.8.2.tgz exports verified
- PostgreSQL pipeline integration: 5 passed, 0 failed (isolated temporary database)

Release publication remains gated on required GitHub Actions checks and will be tagged only from merged main.